### PR TITLE
🔧 Add Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "groupName": "MCP Ecosystem",
+      "description": "Group all MCP-related dependency updates together",
+      "branchTopic": "mcp-ecosystem",
+      "branchPrefix": "renovate/mcp/",
+      "rebaseWhen": "behind-base-branch",
+      "matchPackageNames": [
+        "/mcp/",
+        "/modelcontextprotocol/"
+      ]
+    },
+    {
+      "groupName": "TypeScript & Node types",
+      "matchPackageNames": [
+        "typescript",
+        "@types/node"
+      ]
+    },
+    {
+      "groupName": "Semantic Release",
+      "matchPackageNames": [
+        "/semantic-release/"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Enable Renovate Bot for automated dependency management with grouped update PRs for MCP ecosystem, TypeScript tooling, and semantic-release packages.

Closes #12

## How to read this PR?

Single file: `renovate.json`. Three `packageRules` entries grouping related dependencies, extending Renovate's recommended config.

## How to test this PR?

1. After merge, enable the Renovate GitHub App on the repository (if not already active).
2. Renovate will open an onboarding PR or start creating dependency update PRs.
3. Verify that MCP-related updates appear under `renovate/mcp/*` branches and trigger the `security-mcp.yml` workflow.

## Detailed description (for agents)

Single commit adding `renovate.json` with:
- `config:recommended` as base preset.
- **MCP Ecosystem** group: matches `/mcp/` and `/modelcontextprotocol/` packages, uses `renovate/mcp/` branch prefix (triggers security audit workflow), rebases when behind base branch.
- **TypeScript & Node types** group: keeps `typescript` and `@types/node` together.
- **Semantic Release** group: keeps all `semantic-release*` packages together.
- All GitLab-specific rules (Docker image regex manager, internal registries) removed from the import/gitlab version.