### PR TITLE
🐛 Add .geminiignore to hello-world extension

### DIFF
--- a/extensions/hello-world/.geminiignore
+++ b/extensions/hello-world/.geminiignore
@@ -1,0 +1,3 @@
+# Prevent Gemini from loading extension context at the project level.
+# GEMINI.md is only meant to be loaded when the extension is installed.
+GEMINI.md


### PR DESCRIPTION
Prevent Gemini CLI from loading the hello-world extension's GEMINI.md context file when working in the project root. The context should only be active when the extension is installed in ~/.gemini/extensions/.

The extension-skeleton already has a wildcard .geminiignore — this adds the missing one to hello-world.

## How to read this PR?

Single file: `extensions/hello-world/.geminiignore`.

## How to test this PR?

1. Start a Gemini session in the project root.
2. Verify the hello-world extension context is NOT loaded (the agent should not mention greet/farewell tools unless the extension is installed).

## Detailed description (for agents)

Adds `.geminiignore` to `extensions/hello-world/` excluding `GEMINI.md` from project-level context loading. The `extension-skeleton/` already had a wildcard `*` ignore. New extensions created via `task create-extension` inherit the skeleton's `.gitignore` but should also get a `.geminiignore` — this will be addressed in the skeleton base in a follow-up if needed.