### PR TITLE
Fix GitHub Pages URLs for Actions-based deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ DEVELOPMENT.md                    # Extension development guide
 
 | Date | Event | Title | Links |
 |------|-------|-------|-------|
-| 2026-03-17 | GDG Cloud Paris | L'IA ne fera rien sans nous | [README](communication/talks/gdg-cloud-paris-2026-03-17/README.md) · [Slides](https://hcross.github.io/gemini-configuration/communication/talks/gdg-cloud-paris-2026-03-17/) |
+| 2026-03-17 | GDG Cloud Paris | L'IA ne fera rien sans nous | [README](communication/talks/gdg-cloud-paris-2026-03-17/README.md) · [Slides](https://hcross.github.io/gemini-configuration/talks/gdg-cloud-paris-2026-03-17/) |
 
 ## MCP Servers
 

--- a/communication/talks/gdg-cloud-paris-2026-03-17/README.md
+++ b/communication/talks/gdg-cloud-paris-2026-03-17/README.md
@@ -6,7 +6,7 @@ Talk presented at [GDG Cloud Paris](https://gdg.community.dev/gdg-cloud-paris/) 
 
 > **Language:** French (`lang: fr`). An English version may be added later.
 
-**[View slides online (GitHub Pages)](https://hcross.github.io/gemini-configuration/communication/talks/gdg-cloud-paris-2026-03-17/)**
+**[View slides online (GitHub Pages)](https://hcross.github.io/gemini-configuration/talks/gdg-cloud-paris-2026-03-17/)**
 
 ## Viewing the slides
 
@@ -15,7 +15,7 @@ The presentation was built with [Slides Extended](https://github.com/ebullient/o
 ### Option 1 — GitHub Pages (recommended)
 
 The slides are deployed automatically via GitHub Pages:
-<https://hcross.github.io/gemini-configuration/communication/talks/gdg-cloud-paris-2026-03-17/>
+<https://hcross.github.io/gemini-configuration/talks/gdg-cloud-paris-2026-03-17/>
 
 ### Option 2 — Local HTTP server
 


### PR DESCRIPTION
Fix GitHub Pages URLs after switching the Pages source from "Deploy from a branch" to "GitHub Actions".

The `upload-pages-artifact` action with `path: communication` serves the *contents* of `communication/` as the site root, so URLs should not include `/communication/`.

Closes #26

## How to read this PR?

Single commit: URL correction in both `README.md` (project root) and `communication/talks/gdg-cloud-paris-2026-03-17/README.md` (talk). All occurrences of `/communication/talks/` reverted to `/talks/`.

## How to test this PR?

1. After merge, wait for the Pages deployment workflow to complete
2. Open https://hcross.github.io/gemini-configuration/talks/gdg-cloud-paris-2026-03-17/
3. Slides should render correctly
4. Verify the URLs in both READMEs match the deployed location

## Detailed description (for agents)

### Modified files

- `README.md`: Fixed 1 GitHub Pages URL — removed `/communication` prefix from the talks table link.
- `communication/talks/gdg-cloud-paris-2026-03-17/README.md`: Fixed 2 GitHub Pages URLs — removed `/communication` prefix from the inline link and the Option 1 section.
