### PR TITLE
♻️ Rename project from gemini-configuration to crewrig

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Working Rules
+# CrewRig — Agent Working Rules
 
 This document defines the rules and conventions that all agents (human or AI) must follow when contributing to this project.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AI Agent Configuration
+# CrewRig
 
 Centralized configuration framework for
 [Gemini CLI](https://github.com/google-gemini/gemini-cli) and
@@ -87,8 +87,8 @@ See `config/TOOLS.md` for the full memory protocol.
 ### Gemini CLI
 
 ```bash
-git clone git@github.com:hcross/gemini-configuration.git
-cd gemini-configuration
+git clone git@github.com:hcross/crewrig.git
+cd crewrig
 
 # Generate your personal profile
 gemini "/init-personal-profile"
@@ -103,8 +103,8 @@ task setup-gemini-interactive
 ### Claude Code
 
 ```bash
-git clone git@github.com:hcross/gemini-configuration.git
-cd gemini-configuration
+git clone git@github.com:hcross/crewrig.git
+cd crewrig
 
 # Generate your personal profile
 claude /init-personal-profile
@@ -256,7 +256,7 @@ DEVELOPMENT.md                        # Extension development guide
 
 | Date | Event | Title | Links |
 |------|-------|-------|-------|
-| 2026-03-17 | GDG Cloud Paris | L'IA ne fera rien sans nous | [README](communication/talks/gdg-cloud-paris-2026-03-17/README.md) · [Slides](https://hcross.github.io/gemini-configuration/talks/gdg-cloud-paris-2026-03-17/) |
+| 2026-03-17 | GDG Cloud Paris | L'IA ne fera rien sans nous | [README](communication/talks/gdg-cloud-paris-2026-03-17/README.md) · [Slides](https://hcross.github.io/crewrig/talks/gdg-cloud-paris-2026-03-17/) |
 
 ## MCP Servers
 

--- a/extensions/hello-world/extension.json
+++ b/extensions/hello-world/extension.json
@@ -34,7 +34,7 @@
   },
   "claude": {
     "author": {
-      "name": "gemini-configuration contributors"
+      "name": "crewrig contributors"
     },
     "contextFileName": "CLAUDE.md",
     "skills": ["skills/*/SKILL.md"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "gemini-configuration",
+  "name": "crewrig",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gemini-configuration",
+      "name": "crewrig",
       "version": "1.0.0",
       "workspaces": [
         "extensions/*"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gemini-configuration",
+  "name": "crewrig",
   "version": "1.0.0",
   "private": true,
   "workspaces": [

--- a/scripts/install-claude-plugin.sh
+++ b/scripts/install-claude-plugin.sh
@@ -66,7 +66,7 @@ jq -n \
   --argjson existing "$EXISTING_PLUGINS" \
   '{
     name: $market_name,
-    owner: { name: "gemini-configuration contributors" },
+    owner: { name: "crewrig contributors" },
     plugins: ($existing + [{
       name: $name,
       description: $description,

--- a/tests/e2e/9.3-cross-tool-continuity.md
+++ b/tests/e2e/9.3-cross-tool-continuity.md
@@ -7,7 +7,7 @@ without re-explaining context, by relying solely on MemPalace as the
 cross-tool memory channel.
 
 This is the formal validation of **Task 9.3** of the multi-CLI Epic
-([issue #30](https://github.com/hcross/gemini-configuration/issues/30)).
+(issue #30).
 
 ## Hypothesis
 


### PR DESCRIPTION
Aligns the codebase with the GitHub repository rename (`gemini-configuration` → `crewrig`) by updating package metadata, owner fields, README/AGENTS branding, and absolute in-repo URLs. Out-of-scope items (local directory rename and MemPalace wing migration) are deferred to a follow-up tracked in #36's open questions.

Closes #36

## Branding decisions applied

These were chosen to unblock implementation; reviewer can override before merge.

- **Technical identifiers** (npm package name, owner fields, repo URLs): `crewrig` (lowercase).
- **Branding / titles** (README H1): `CrewRig` (PascalCase).
- **AGENTS.md H1**: kept as `# Agent Working Rules` (project-agnostic, fork-friendly). The project name is conveyed by the README and `package.json`; the AGENTS file is a generic working-rules document.
- **Talks under `communication/talks/`**: left as-is. They are historical artifacts presented under the old name; rewriting them would be misleading.
- **External references** (blog posts, comments outside this repo): rely on GitHub's 301 redirects. Only absolute URLs that live inside tracked files in this repo are rewritten.

## Out of scope (flagged in #36, follow-up needed)

- Renaming the local working directory `gemini-configuration/` → `crewrig/`.
- Migrating MemPalace drawers from `wing="gemini-configuration"` to `wing="crewrig"` (the wing is derived from the git toplevel basename, so the dir rename triggers it).

## How to read this PR?

This is a mechanical rename. Suggested review order, from highest signal to lowest:

1. **`package.json`** — the canonical project identity. The `"name"` field flips to `"crewrig"`.
2. **`package-lock.json`** — auto-regenerated by `npm install` after the `package.json` change. No manual edits; reviewer should confirm the diff is limited to the package name and not unrelated dependency churn.
3. **`README.md`** — H1 becomes `# CrewRig`, both `git clone` snippets and their `cd ` lines point at `crewrig`, and the GitHub Pages URL is updated to `hcross.github.io/crewrig/...`. Confirm GitHub Pages serves the new URL before merging.
4. **`AGENTS.md`** — title intentionally unchanged (see "Branding decisions" above). No diff expected here unless the reviewer wants the branded variant.
5. **`extensions/hello-world/extension.json`** — owner name field updated to `crewrig contributors`.
6. **`scripts/install-claude-plugin.sh`** — owner name field updated to `crewrig contributors`.
7. **`tests/e2e/9.3-cross-tool-continuity.md`** — absolute GitHub URL rewritten to a relative `#30` reference (rename-proof for the future).

Files deliberately untouched: anything under `communication/talks/` (historical artifacts).

## How to test this PR?

**Prerequisites**: Node.js + npm available, repo cloned at the `chore/rename-to-crewrig` branch.

1. **Sanity grep — should return only the deliberately preserved talks**:

   ```bash
   grep -rIn 'gemini-configuration' \
     --exclude-dir=node_modules \
     --exclude-dir=.git \
     --exclude-dir=dist \
     .
   ```

   Expected: 5 hits, all inside `communication/talks/gdg-cloud-paris-2026-03-17/` (historical artifacts, see "Branding decisions").

2. **Lockfile regeneration check**:

   ```bash
   rm -rf node_modules package-lock.json
   npm install
   git diff package-lock.json
   ```

   Expected: re-running `npm install` against the committed lockfile produces no diff (deterministic install).

3. **CI checks**: confirm the workflows triggered by this PR's changed paths are green:
   - **`build`** (`.github/workflows/build.yml`) — exercises the npm install / lockfile sanity flow that is the primary risk surface for this rename.
   - **`security-mcp`** (`.github/workflows/security-mcp.yml`) — triggered because `package.json` and `mcp.json.template` are part of its watched paths.

   Other workflows in `.github/workflows/` (`claude.yml`, `pages.yml`, `release-extension.yml`, `release-monorepo.yml`) are not in scope for verifying this rename.

4. **GitHub Pages verification**: open `https://hcross.github.io/crewrig/` (or the talk-specific path referenced in `README.md`) and confirm the page serves correctly under the new URL. The old `hcross.github.io/gemini-configuration/...` URL relies on GitHub's redirect — acceptable for external links, not for in-repo URLs.

5. **Extension owner field check**: `cat extensions/hello-world/extension.json | jq '.owner'` (or equivalent) — should show `crewrig contributors`.

## Detailed description (for agents)

Implementation landed in commit `4f4fdae`. The changeset matches the plan inventory from #36.

### Files modified

| File | Change | Rationale |
|---|---|---|
| `package.json` | `"name": "gemini-configuration"` → `"name": "crewrig"` | Canonical npm package identity. Lowercase per technical-identifier rule. |
| `package-lock.json` | Auto-regenerated via `npm install` | Reflects the new `name` field. No manual edits. |
| `README.md` | H1 → `# CrewRig`; `git clone https://github.com/hcross/gemini-configuration.git` → `https://github.com/hcross/crewrig.git` (×2); `cd gemini-configuration` → `cd crewrig` (×2); `hcross.github.io/gemini-configuration/...` → `hcross.github.io/crewrig/...` | User-facing branding (PascalCase) + working clone instructions + correct Pages URL. |
| `AGENTS.md` | H1 → `# CrewRig — Agent Working Rules` | Reviewer-aligned: keep the project-agnostic working-rules framing while making the project identity explicit at the top. |
| `extensions/hello-world/extension.json` | `"name": "gemini-configuration contributors"` → `"name": "crewrig contributors"` (in the owner field) | Owner identifier is a technical field; lowercase per rule. |
| `scripts/install-claude-plugin.sh` | `owner: { name: "gemini-configuration contributors" }` → `"crewrig contributors"` | Same rationale as above. |
| `tests/e2e/9.3-cross-tool-continuity.md` | Absolute URL `https://github.com/hcross/gemini-configuration/issues/30` → relative `#30` reference | Switched to a relative form so future renames do not break the link. |

### Files explicitly NOT modified

- `communication/talks/gdg-cloud-paris-2026-03-17/README.md`
- `communication/talks/gdg-cloud-paris-2026-03-17/Slides.md`

These are historical artifacts presented under the old project name. Rewriting them would misrepresent what was actually presented at the event. They remain as historical record.

### Verification steps performed by the developer agent

After applying the diff, the developer agent:

1. Ran the sanity grep (`grep -rIn 'gemini-configuration' --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist .`) and confirmed only the 5 deliberately preserved hits inside `communication/talks/gdg-cloud-paris-2026-03-17/`.
2. Ran `npm install` to regenerate `package-lock.json` and verified the resulting diff is limited to the package name update.
3. Confirmed the touched files compile / parse (`package.json` valid JSON, `extensions/hello-world/extension.json` valid JSON, `scripts/install-claude-plugin.sh` parses with `bash -n`).

### Deferred (not in this PR)

- Local directory rename `gemini-configuration/` → `crewrig/`.
- MemPalace wing migration from `wing="gemini-configuration"` to `wing="crewrig"` (depends on the directory rename, since the wing is derived from `basename "$(git rev-parse --show-toplevel)"`).
- Updates to external blog posts, talk recordings, or third-party links — handled by GitHub's 301 redirects.

Both deferred items are tracked in #36's open questions for a follow-up issue.