### PR TITLE
📝 Codify scripting conventions and fix set -e false-failure traps

### DIFF
--- a/.github/workflows/scripting-conventions.yml
+++ b/.github/workflows/scripting-conventions.yml
@@ -1,0 +1,46 @@
+name: Scripting Conventions
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/**"
+      - "hooks/**"
+      - ".github/workflows/scripting-conventions.yml"
+
+jobs:
+  grep-anti-patterns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Flag chained-test exit pattern under set -e
+        # Catches: `[ test ] && cmd && exit N` and `[[ test ]] && cmd && exit N`
+        # See docs/scripting-conventions.md, Rule 3.
+        run: |
+          set -uo pipefail
+          hits=$(grep -rnE '\[\[?[^]]*\]\]?[[:space:]]+&&[[:space:]]+.*&&[[:space:]]+exit[[:space:]]+[0-9]+' \
+                  scripts/ hooks/ \
+                | grep -v 'acknowledged-exception:' || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Rule 3 violation — chained-test exit pattern (see docs/scripting-conventions.md)"
+            echo "$hits"
+            exit 1
+          fi
+          echo "Rule 3 clean."
+
+      - name: Flag bare/broad except in shell-embedded Python
+        # Catches: `except:` and `except Exception:` and `except BaseException:`
+        # in heredoc'd Python inside shell scripts under scripts/ and hooks/.
+        # See docs/scripting-conventions.md, Rule 1.
+        run: |
+          set -uo pipefail
+          hits=$(grep -rnE 'except[[:space:]]*:|except[[:space:]]+(Exception|BaseException)[[:space:]]*(as[[:space:]]+\w+)?[[:space:]]*:' \
+                  scripts/ hooks/ \
+                | grep -v 'acknowledged-exception:' || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Rule 1 violation — bare/broad except (see docs/scripting-conventions.md)"
+            echo "$hits"
+            exit 1
+          fi
+          echo "Rule 1 clean."

--- a/.github/workflows/scripting-conventions.yml
+++ b/.github/workflows/scripting-conventions.yml
@@ -15,8 +15,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Flag chained-test exit pattern under set -e
-        # Catches: `[ test ] && cmd && exit N` and `[[ test ]] && cmd && exit N`
-        # See docs/scripting-conventions.md, Rule 3.
+        # One-shot recursive grep — no surrounding loop. Targets `scripts/`
+        # and `hooks/` directly via `grep -r`. See docs/scripting-conventions.md,
+        # Rule 3.
+        #
+        # Regex breakdown (matches `[ test ] && cmd && exit N`
+        # and `[[ test ]] && cmd && exit N`):
+        #   \[\[?            opening `[` or `[[`
+        #   [^]]*            test body (anything except a closing `]`)
+        #   \]\]?            closing `]` or `]]`
+        #   [[:space:]]+&&   whitespace + first `&&`
+        #   .*&&             middle clause + second `&&`
+        #   [[:space:]]+exit[[:space:]]+[0-9]+   `exit N`
         run: |
           set -uo pipefail
           hits=$(grep -rnE '\[\[?[^]]*\]\]?[[:space:]]+&&[[:space:]]+.*&&[[:space:]]+exit[[:space:]]+[0-9]+' \

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,4 +1,5 @@
 {
+  "_comment": "MD024 siblings_only lets docs repeat ### Why / ### Bad / ### Good under each rule in docs/scripting-conventions.md (and any future doc that uses the same recurring sub-section pattern). markdownlint ignores unknown top-level keys.",
   "default": true,
   "MD013": false,
   "MD024": { "siblings_only": true },

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,6 +1,7 @@
 {
   "default": true,
   "MD013": false,
+  "MD024": { "siblings_only": true },
   "MD034": false,
   "MD060": false
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,3 +151,6 @@ Each extension is an independent npm package with its own versioning. See
    build generates both tool outputs. See `community-config/FORMAT.md`.
 6. **Extensions**: use `extension.json` manifest for new extensions.
    See `extension-skeleton/EXTENSION-FORMAT.md`.
+7. **Shell + Python glue**: follow the rules in
+   [`docs/scripting-conventions.md`](docs/scripting-conventions.md). They
+   exist because each one has already shipped a real bug.

--- a/docs/scripting-conventions.md
+++ b/docs/scripting-conventions.md
@@ -172,17 +172,27 @@ downstream check kept producing an actionable error.
 ### Bad
 
 ```python
-# Loop scans drawers, only checks the slice it saw
+# Pagination loop: imagine it terminates after the first page (broken
+# upstream — only 100 of 11 850 drawers scanned).
 for drawer in drawers_seen_so_far:
-    ...
-if all_drawers_failed_format(drawers_seen_so_far):
-    sys.exit(3)  # looks correct, says nothing about wing size
+    if not matches_format(drawer):
+        skipped_format += 1
+
+# This downstream check fires on the partial sample and looks correct.
+# The user sees an actionable error message and concludes the script
+# worked. The 11 750 unscanned drawers stay invisible — the wedge
+# upstream is hidden because the downstream check refused to look past
+# the slice it was handed.
+if skipped_format == len(drawers_seen_so_far):
+    sys.exit(3)  # silent on input size — silent on the wedge
 ```
 
 ### Good
 
 ```python
-# Surface what was actually scanned, so a wedge upstream is visible
+# Surface what was actually scanned, so a wedge upstream is visible.
+# A reviewer comparing "Scanned: 100" against an expected wing size of
+# ~10 000 catches the upstream pagination bug at a glance.
 print(f"Scanned: {stats['total_scanned']} drawer(s)")
 print(f"Format mismatch: {stats['skipped_format']}")
 if stats["skipped_format"] == stats["total_scanned"] > 0:

--- a/docs/scripting-conventions.md
+++ b/docs/scripting-conventions.md
@@ -1,0 +1,229 @@
+# Scripting Conventions
+
+Bash and Python glue scripts under `scripts/` and `hooks/` follow these rules.
+The list is short on purpose: each rule comes from a real production incident
+where a script silently misbehaved for weeks. If you have a real reason to
+break a rule, mark the line with `# acknowledged-exception: <reason>` so the
+exception is greppable.
+
+---
+
+## Rule 1 — No broad or bare `except` in Python glue
+
+A `try` block must catch the narrowest exception that justifies the recovery
+path. Bare `except:`, `except Exception:`, and `except BaseException:` are
+banned because they silently swallow `ImportError`, `KeyboardInterrupt`,
+`SystemExit`, and unrelated runtime bugs.
+
+### Why
+
+The session-transcript hook (`hooks/mempalace-transcript.sh`) silently
+dropped every entry for **months** after the MemPalace v3.x upgrade. A broad
+`except` was hiding an `ImportError` for a class that no longer existed
+(`PalaceGraph`). The fix landed in `1429cdb`; this rule exists so the
+failure mode does not return.
+
+### Bad
+
+```python
+try:
+    from mempalace.mcp_server import tool_add_drawer
+    result = tool_add_drawer(...)
+except:
+    pass  # never know what failed
+```
+
+### Good
+
+```python
+try:
+    from mempalace.mcp_server import tool_add_drawer
+except ImportError as e:
+    print(f"IMPORT_ERROR: {e}", file=sys.stderr)
+    sys.exit(2)
+
+result = tool_add_drawer(...)
+if not result.get("success"):
+    print(f"ADD_FAILED: {result.get('error', 'unknown')}", file=sys.stderr)
+    sys.exit(3)
+```
+
+If continuing past a failure is genuinely correct, surface it:
+
+```python
+try:
+    drawer_dt = datetime.strptime(date_str, "%Y-%m-%d")
+except ValueError:
+    stats["skipped_format"] += 1   # counted, not silent
+    continue
+```
+
+If `stats["skipped_format"] == total_scanned`, escalate — that means the
+recovery path is masking a structural assumption error.
+
+---
+
+## Rule 2 — No success-log-before-result
+
+A log line that says "did X" must be guarded by the actual outcome of X.
+Logs that fire regardless of the underlying call's exit status produce
+months of "looks fine" with zero data flowing.
+
+### Why
+
+The transcript hook printed `mempalace-transcript: persisted ...` to stderr
+on **every** invocation, including the ones where the underlying Python
+heredoc had crashed during import. The success line lived outside the
+return-code check that gated it. PR #31 / commit `1429cdb`.
+
+### Bad
+
+```bash
+"$MEMPALACE_PYTHON" - <<PYEOF
+... # may exit non-zero
+PYEOF
+echo "persisted entry"  # fires regardless
+```
+
+### Good
+
+```bash
+STATUS=$("$MEMPALACE_PYTHON" - 2>&1 <<'PYEOF'
+... # may exit non-zero
+PYEOF
+)
+STATUS_RC=$?
+if [ "$STATUS_RC" -eq 0 ]; then
+  echo "persisted entry"
+else
+  echo "FAILED to persist (rc=$STATUS_RC): $STATUS" >&2
+fi
+```
+
+The principle generalizes: the log line must be on the success branch of an
+`if` that read the actual result.
+
+---
+
+## Rule 3 — No `[ test ] && cmd && exit N` under `set -e`
+
+Use an explicit `if … then … fi` block. The chained-test pattern looks like
+a one-line guard, but under `set -e` it kills the script on the **success**
+path: when the test is false, the compound returns non-zero, and `set -e`
+aborts before the next intended statement. The script appears to fail
+silently on every successful run.
+
+### Why
+
+Surfaced in commit `212318c`:
+
+> The pattern `[ -z "$FOUND" ] && echo "..." && exit 1` would kill the
+> script via `set -e` whenever FOUND was set (i.e., on every successful
+> install), because the negated test returns non-zero.
+
+The trap repeats itself across files because the one-liner is shorter than
+the `if` block. It is shorter; it is also wrong.
+
+### Bad
+
+```bash
+set -e
+[ ! -d "$REPO_DIR/extensions/$EXT" ] && echo "Error: extension '$EXT' not found." && exit 1
+do_install "$EXT"
+```
+
+### Good
+
+```bash
+set -e
+if [ ! -d "$REPO_DIR/extensions/$EXT" ]; then
+  echo "Error: extension '$EXT' not found." >&2
+  exit 1
+fi
+do_install "$EXT"
+```
+
+The explicit `if` block makes the failure path unambiguous and the success
+path immune to the `set -e` trap. Send the error to `>&2` while you are
+there.
+
+A single-`&&` form (`[[ ! cond ]] && exit 1`) is the same family in lighter
+form and gets the same treatment.
+
+---
+
+## Rule 4 — Defense-in-depth checks must verify their inputs
+
+When a check fires only on a partial view of its input, the check passing
+is not the same as the underlying invariant being true. Make checks
+*independently verifiable* — surface the size of the input they actually
+saw, so the next reader can spot a wedge upstream.
+
+### Why
+
+PR #39 (`scripts/prune-transcripts.sh`) shipped a pagination loop whose
+termination condition (`count <= offset + len(drawers)`) misread the API
+contract and exited after the first page. The script had a perfectly
+correct format-mismatch escalation that fired on the 100 drawers it saw,
+hiding the fact that 11 850 of 11 850 drawers in the wing had not been
+scanned. Two review cycles missed the upstream wedge because the
+downstream check kept producing an actionable error.
+
+### Bad
+
+```python
+# Loop scans drawers, only checks the slice it saw
+for drawer in drawers_seen_so_far:
+    ...
+if all_drawers_failed_format(drawers_seen_so_far):
+    sys.exit(3)  # looks correct, says nothing about wing size
+```
+
+### Good
+
+```python
+# Surface what was actually scanned, so a wedge upstream is visible
+print(f"Scanned: {stats['total_scanned']} drawer(s)")
+print(f"Format mismatch: {stats['skipped_format']}")
+if stats["skipped_format"] == stats["total_scanned"] > 0:
+    print("Error: 100% format mismatch on a sample of "
+          f"{stats['total_scanned']} drawer(s).", file=sys.stderr)
+    sys.exit(3)
+```
+
+A reviewer comparing "Scanned: 100" against an expected wing size of
+~10 000 catches the upstream bug at a glance.
+
+---
+
+## Acknowledged exceptions
+
+If a real reason justifies breaking one of these rules (e.g. a third-party
+library that requires a bare `except`), tag the line:
+
+```bash
+# acknowledged-exception: vendored library raises bare strings, not exceptions
+[ -f "$marker" ] && load_legacy "$marker" && exit 0
+```
+
+```python
+# acknowledged-exception: aiohttp 3.x raises CancelledError as bare except path
+try:
+    await client.fetch(url)
+except:  # noqa: E722
+    cleanup()
+    raise
+```
+
+The tag is greppable, so the exception is auditable. New tags should be
+discussed in the PR.
+
+---
+
+## CI grep check
+
+`.github/workflows/scripting-conventions.yml` runs a small `grep` pass on
+`scripts/` and `hooks/` to flag new occurrences of the chained-test pattern
+and bare `except`. The check is intentionally lightweight; it does not try
+to be a full linter. False positives are handled with the
+`acknowledged-exception` tag.

--- a/scripts/install-extension.sh
+++ b/scripts/install-extension.sh
@@ -24,7 +24,10 @@ do_install() {
 }
 
 if [ -n "$EXT" ]; then
-  [ ! -d "$REPO_DIR/extensions/$EXT" ] && echo "Error: extension '$EXT' not found." && exit 1
+  if [ ! -d "$REPO_DIR/extensions/$EXT" ]; then
+    echo "Error: extension '$EXT' not found." >&2
+    exit 1
+  fi
   do_install "$EXT"
 else
   for dir in "$REPO_DIR"/extensions/*/; do

--- a/scripts/manage-claude-component.sh
+++ b/scripts/manage-claude-component.sh
@@ -27,7 +27,9 @@ if [ "$MODE" = "link" ]; then
   echo "Only use if you trust all branches in this repository."
   read -p "Continue? [y/N] " -n 1 -r
   echo ""
-  [[ ! $REPLY =~ ^[Yy]$ ]] && exit 1
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    exit 1
+  fi
 fi
 
 # --- Normalize type ---

--- a/scripts/manage-workspace-component.sh
+++ b/scripts/manage-workspace-component.sh
@@ -108,7 +108,10 @@ case "$TYPE" in
 
     if [ -n "$NAME" ]; then
       JSON="$SRC_DIR/$NAME.json"
-      [ ! -f "$JSON" ] && echo "Error: '$NAME.json' not found in community-config/$TYPE" && exit 1
+      if [ ! -f "$JSON" ]; then
+        echo "Error: '$NAME.json' not found in community-config/$TYPE" >&2
+        exit 1
+      fi
       merge_json "$JSON" "$KEY"
     else
       for item in "$SRC_DIR"/*.json; do

--- a/scripts/package-extension.sh
+++ b/scripts/package-extension.sh
@@ -8,7 +8,10 @@ if [ -z "$EXT" ]; then
   exit 1
 fi
 
-[ ! -d "$REPO_DIR/extensions/$EXT" ] && echo "Error: extension '$EXT' not found." && exit 1
+if [ ! -d "$REPO_DIR/extensions/$EXT" ]; then
+  echo "Error: extension '$EXT' not found." >&2
+  exit 1
+fi
 
 mkdir -p "$REPO_DIR/dist"
 cd "$REPO_DIR/extensions/$EXT" && npm pack --pack-destination "$REPO_DIR/dist"


### PR DESCRIPTION
Codifies the four anti-patterns surfaced during the multi-CLI Epic (#30) and the prune-transcripts review (#39) into a dedicated `docs/scripting-conventions.md`. Audits `scripts/` and `hooks/` for occurrences and fixes the four real bugs that replicated the `set -e` chained-test trap from `212318c`.

## How to read this PR?

1. **`docs/scripting-conventions.md`** — the new conventions doc. Four rules, each tied to a real production incident, each with bad/good examples. Rules 1 and 3 are CI-enforced via grep; Rules 2 and 4 are review-enforced.
2. **`CONTRIBUTING.md`** — one-line entry under Standards pointing at the doc.
3. **The four script patches** — same shape across all four (`if … then … exit … fi` instead of `[ test ] && cmd && exit N`). Read one to know the others.
4. **`.github/workflows/scripting-conventions.yml`** — the lightweight grep workflow with the `acknowledged-exception:` escape hatch.

## How to test this PR?

\`\`\`bash
# Syntax sanity on patched scripts
for f in scripts/install-extension.sh scripts/package-extension.sh \\
         scripts/manage-workspace-component.sh scripts/manage-claude-component.sh; do
  bash -n \"\$f\" && echo \"OK: \$f\"
done

# Verify the CI grep is silent on the patched tree
grep -rnE '\\[\\[?[^]]*\\]\\]?[[:space:]]+&&[[:space:]]+.*&&[[:space:]]+exit[[:space:]]+[0-9]+' \\
  scripts/ hooks/ | grep -v 'acknowledged-exception:'   # expect empty
\`\`\`

The CI workflow itself runs only on PRs touching \`scripts/\`, \`hooks/\`, or the workflow file — so this PR triggers it.

## Detailed description (for agents)

### Files changed

**1. \`docs/scripting-conventions.md\` (NEW, 4 rules)**

- **Rule 1 — No broad/bare \`except\` in Python glue.** Tied to \`1429cdb\` transcript-hook silent-drop.
- **Rule 2 — No success-log-before-result.** Same incident.
- **Rule 3 — No \`[ test ] && cmd && exit N\` under \`set -e\`.** Direct citation of \`212318c\`.
- **Rule 4 — Defense-in-depth checks must verify their inputs.** Drawn from PR #39's pagination wedge.
- Acknowledged-exception escape hatch (\`# acknowledged-exception: <reason>\`).

**2. \`CONTRIBUTING.md\` (MODIFIED)** — Added Standard #7 pointing at the new doc.

**3. Four script patches, all the same shape**

| File | Pattern fixed |
|---|---|
| \`scripts/install-extension.sh:27\` | chained \`[ ! -d ] && echo … && exit 1\` |
| \`scripts/package-extension.sh:11\` | same |
| \`scripts/manage-workspace-component.sh:111\` | same |
| \`scripts/manage-claude-component.sh:30\` | single-\`&&\` variant |

**4. \`.github/workflows/scripting-conventions.yml\` (NEW)** — grep workflow. Honors \`acknowledged-exception:\` tag.

### Out of scope

- Setup scripts' \`jq | mv\` chains — borderline \`&&\` reliance on \`set -e\`, no real bug today.
- Rule 2 CI enforcement — too contextual to flag without high false-positive rate. Review-enforced.

Logbook: this PR is its own logbook (per user instruction). See updates on issue #32.