### PR TITLE
✨ PR A — Format extension: provenance block + ${SHELL_LIKE} placeholder resolver

### DIFF
--- a/.claude/skills/ci-workflow-engineering/SKILL.md
+++ b/.claude/skills/ci-workflow-engineering/SKILL.md
@@ -9,6 +9,10 @@ allowed-tools:
   - Grep
   - Glob
 user-invocable: true
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
 ---
 
 

--- a/.gemini/skills/ci-workflow-engineering/SKILL.md
+++ b/.gemini/skills/ci-workflow-engineering/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: ci-workflow-engineering
 description: "Structured approach for building, debugging, and hardening CI/CD pipelines. Activate when the agent needs to: create new workflow definitions, diagnose failing jobs, validate pipeline changes on a branch before merge, or integrate platform-specific resources (secrets, registries, certificates)."
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
 ---
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build & Validate
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
   push:
-    branches: [main]
+    branches: [main, "release/**"]
     tags-ignore:
       - "**"
 

--- a/.github/workflows/scripting-conventions.yml
+++ b/.github/workflows/scripting-conventions.yml
@@ -2,7 +2,7 @@ name: Scripting Conventions
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
     paths:
       - "scripts/**"
       - "hooks/**"

--- a/community-config/FORMAT.md
+++ b/community-config/FORMAT.md
@@ -172,6 +172,63 @@ description: <description>
 <body>
 ```
 
+## Provenance & Forks
+
+Components carry a `provenance:` block in their frontmatter that survives
+forks and lets feedback flow back to the right repo. The block is
+optional but recommended for any component intended to be re-shared.
+
+```yaml
+---
+name: my-component
+description: "..."
+type: skill
+provenance:
+  canonical: "${CANONICAL_REPO}"   # origin (audit + license trace)
+  feedback:  "${FEEDBACK_REPO}"    # MR target (defaults to canonical)
+  version:   "1.0.0"               # version at build/import
+---
+```
+
+### Placeholder resolution
+
+`${SHELL_LIKE}` placeholders are resolved at **build time** by
+`scripts/build-components.sh` from `crewrig.config.toml` at the repo
+root. Each line in the config file maps an uppercased key to a value:
+
+```toml
+canonical_repo = "https://github.com/hcross/crewrig"
+feedback_repo  = "https://github.com/hcross/crewrig"
+```
+
+The build then substitutes `${CANONICAL_REPO}` and `${FEEDBACK_REPO}`
+verbatim in the generated outputs (`.gemini/`, `.claude/`). Source
+files keep the placeholders untouched.
+
+### Forking workflow
+
+When you fork crewrig (or a fork of it):
+
+1. Edit `crewrig.config.toml` to point at your URLs. Typically:
+   - Keep `canonical_repo` pointing at the upstream you forked from
+     (audit trail).
+   - Set `feedback_repo` to your own repo so harness feedback lands
+     internally.
+2. Run `task build-components` to regenerate the outputs with your
+   values.
+3. Commit both `crewrig.config.toml` and the regenerated outputs.
+
+The `version:` field in `provenance:` is a literal per-component
+string, not a placeholder. It tracks the component's own evolution
+independently from the host repo.
+
+### Components without a `provenance:` block
+
+Components shipped before the provenance contract existed (or
+intentionally unscoped) build unchanged — the resolver only acts on
+content that actually contains placeholders. There is no automatic
+backfill.
+
 ## Parser Requirements
 
 The build script (`scripts/build-components.sh`) requires:

--- a/community-config/FORMAT.md
+++ b/community-config/FORMAT.md
@@ -201,9 +201,11 @@ canonical_repo = "https://github.com/hcross/crewrig"
 feedback_repo  = "https://github.com/hcross/crewrig"
 ```
 
-The build then substitutes `${CANONICAL_REPO}` and `${FEEDBACK_REPO}`
-verbatim in the generated outputs (`.gemini/`, `.claude/`). Source
-files keep the placeholders untouched.
+The build substitutes every `${KEY}` placeholder it encounters in the
+generated outputs (`.gemini/`, `.claude/`) — frontmatter **and** body —
+not only inside the `provenance:` block. This is intentional: components
+may reference `${CANONICAL_REPO}` or other config keys in their prompt
+body too. Source files keep the placeholders untouched.
 
 ### Forking workflow
 

--- a/community-config/skills/ci-workflow-engineering/SKILL.md
+++ b/community-config/skills/ci-workflow-engineering/SKILL.md
@@ -5,6 +5,10 @@ description: "Structured approach for building, debugging, and hardening CI/CD
   diagnose failing jobs, validate pipeline changes on a branch before merge,
   or integrate platform-specific resources (secrets, registries, certificates)."
 type: skill
+provenance:
+  canonical: "${CANONICAL_REPO}"
+  feedback: "${FEEDBACK_REPO}"
+  version: "1.0.0"
 claude:
   allowed-tools:
     - Read

--- a/crewrig.config.toml
+++ b/crewrig.config.toml
@@ -1,0 +1,16 @@
+# Crewrig fork configuration.
+#
+# Each fork commits its own values here. The build pipeline reads this file
+# during `task build-components` and substitutes ${UPPERCASED_KEY} placeholders
+# in source files (community-config/**) with the values below.
+#
+# Forks targeting an internal mirror typically:
+#   - Keep `canonical_repo` pointing at the upstream they forked from
+#     (audit trail, license trace).
+#   - Override `feedback_repo` so MRs from the harness curator land on
+#     their own internal repo, not the public upstream.
+#
+# See community-config/FORMAT.md (Provenance Block) and issue #41 for context.
+
+canonical_repo = "https://github.com/hcross/crewrig"
+feedback_repo  = "https://github.com/hcross/crewrig"

--- a/scripts/build-components.sh
+++ b/scripts/build-components.sh
@@ -14,10 +14,14 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 COMMUNITY_DIR="$REPO_DIR/community-config"
-TARGET="${1:-all}"
+TARGET="all"
 CHECK_MODE=false
 
 # --- Parse arguments ---
+# Note: do not seed TARGET from $1. The previous form `TARGET="${1:-all}"`
+# silently set TARGET to `--check` when invoked as `bash ... --check`,
+# which made every later `[ "$TARGET" = "all" ]` test fail and turned the
+# whole --check mode into a silent no-op.
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --target) TARGET="$2"; shift 2 ;;
@@ -30,6 +34,106 @@ done
 command -v yq >/dev/null 2>&1 || { echo "Error: yq is required. Install with: brew install yq"; exit 1; }
 
 DRIFT_FOUND=false
+
+# --- Crewrig fork configuration ---
+# Reads crewrig.config.toml at the repo root. Each `key = "value"` line becomes
+# a CFG_<UPPERCASED_KEY> shell variable, and the placeholder ${UPPERCASED_KEY}
+# in component sources resolves to its value at build time. Forks edit this
+# file to redirect provenance/feedback URLs without touching the components.
+CFG_KEYS=""
+load_crewrig_config() {
+  local config="$REPO_DIR/crewrig.config.toml"
+  if [ ! -f "$config" ]; then
+    echo "Warning: $config not found — placeholders will be left literal." >&2
+    return 0
+  fi
+  while IFS='=' read -r raw_key raw_value; do
+    local key
+    key=$(printf '%s' "$raw_key" | tr -d '[:space:]')
+    [ -z "$key" ] && continue
+    case "$key" in \#*) continue ;; esac
+    local value
+    value=$(printf '%s' "$raw_value" | sed -E 's/^[[:space:]]*"?//; s/"?[[:space:]]*$//')
+    local upper
+    upper=$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')
+    printf -v "CFG_${upper}" '%s' "$value"
+    CFG_KEYS="$CFG_KEYS $upper"
+  done < "$config"
+}
+
+# Substitute ${KEY} placeholders in stdin/content with values loaded above.
+# Sed special chars (& \ |) in values are escaped before substitution.
+resolve_placeholders() {
+  local content="$1"
+  local key
+  for key in $CFG_KEYS; do
+    local var_name="CFG_${key}"
+    local value="${!var_name}"
+    local escaped
+    escaped=$(printf '%s' "$value" | sed -e 's/[&\\|]/\\&/g')
+    content=$(printf '%s' "$content" | sed "s|\${${key}}|${escaped}|g")
+  done
+  printf '%s' "$content"
+}
+
+load_crewrig_config
+
+# --- Provenance propagation ---
+# Components may declare a `provenance:` block in their source frontmatter.
+# This block must travel to every output that supports YAML frontmatter, so
+# installers and the harness curator can read where the component came from.
+# The build only natively copies name+description, so we inject provenance
+# explicitly at the bottom of the output frontmatter.
+
+# Returns the provenance YAML block ready to splice into a frontmatter, or
+# empty if the source has no provenance: block.
+provenance_block() {
+  local source="$1"
+  local has_prov
+  has_prov=$(extract_frontmatter "$source" | yq -r 'has("provenance")' 2>/dev/null || echo "false")
+  if [ "$has_prov" != "true" ]; then
+    return 0
+  fi
+  printf 'provenance:\n'
+  extract_frontmatter "$source" \
+    | yq -r '.provenance | to_entries | .[] | "  " + .key + ": \"" + .value + "\""' 2>/dev/null
+}
+
+# Splice a provenance block before the closing `---` of the first frontmatter
+# of `content`. No-op if the source has no provenance.
+# Uses a tempfile to feed multi-line provenance into awk — BSD awk does not
+# accept newlines in `-v var=...`, so we read the block via getline instead.
+inject_provenance() {
+  local content="$1"
+  local source="$2"
+  local prov
+  prov=$(provenance_block "$source")
+  if [ -z "$prov" ]; then
+    printf '%s' "$content"
+    return 0
+  fi
+  local prov_file
+  prov_file=$(mktemp -t crewrig-prov.XXXXXX)
+  printf '%s\n' "$prov" > "$prov_file"
+  printf '%s' "$content" | awk -v provfile="$prov_file" '
+    BEGIN {
+      while ((getline line < provfile) > 0) {
+        prov = (prov == "" ? line : prov "\n" line)
+      }
+      close(provfile)
+      c = 0; injected = 0
+    }
+    /^---$/ {
+      c++
+      if (c == 2 && !injected) {
+        print prov
+        injected = 1
+      }
+    }
+    { print }
+  '
+  rm -f "$prov_file"
+}
 
 # --- Helpers ---
 
@@ -62,10 +166,18 @@ yaml_nested() {
   fi
 }
 
-# Compare file with expected content, report drift
+# Compare file with expected content, report drift.
+# When a source path is passed as $3, splices any `provenance:` block from
+# that source into the output frontmatter before resolving placeholders.
 check_or_write() {
   local target_file="$1"
   local content="$2"
+  local source="${3:-}"
+
+  if [ -n "$source" ]; then
+    content=$(inject_provenance "$content" "$source")
+  fi
+  content=$(resolve_placeholders "$content")
 
   if [ "$CHECK_MODE" = true ]; then
     if [ ! -f "$target_file" ]; then
@@ -118,7 +230,7 @@ description: "$description"
 $body
 GEMINI_EOF
       )
-      check_or_write "$REPO_DIR/.gemini/skills/$name/SKILL.md" "$gemini_content"
+      check_or_write "$REPO_DIR/.gemini/skills/$name/SKILL.md" "$gemini_content" "$source"
     fi
 
     # --- Claude Code output ---
@@ -175,7 +287,7 @@ $claude_frontmatter
 $body
 CLAUDE_EOF
       )
-      check_or_write "$REPO_DIR/.claude/skills/$name/SKILL.md" "$claude_content"
+      check_or_write "$REPO_DIR/.claude/skills/$name/SKILL.md" "$claude_content" "$source"
     fi
   done
 }
@@ -207,7 +319,7 @@ build_commands() {
 prompt = \"\"\"
 $body
 \"\"\""
-      check_or_write "$REPO_DIR/.gemini/commands/$name.toml" "$toml_content"
+      check_or_write "$REPO_DIR/.gemini/commands/$name.toml" "$toml_content" "$source"
     fi
 
     # --- Claude Code output: SKILL.md ---
@@ -236,7 +348,7 @@ $claude_frontmatter
 $body
 CLAUDE_EOF
       )
-      check_or_write "$REPO_DIR/.claude/skills/$name/SKILL.md" "$claude_content"
+      check_or_write "$REPO_DIR/.claude/skills/$name/SKILL.md" "$claude_content" "$source"
     fi
   done
 }
@@ -279,7 +391,7 @@ description: "$description"
 $body
 CLAUDE_EOF
       )
-      check_or_write "$REPO_DIR/.claude/agents/$name/AGENT.md" "$claude_content"
+      check_or_write "$REPO_DIR/.claude/agents/$name/AGENT.md" "$claude_content" "$source"
     fi
   done
 }

--- a/scripts/build-components.sh
+++ b/scripts/build-components.sh
@@ -61,8 +61,13 @@ load_crewrig_config() {
   done < "$config"
 }
 
-# Substitute ${KEY} placeholders in stdin/content with values loaded above.
-# Sed special chars (& \ |) in values are escaped before substitution.
+# Substitute ${KEY} placeholders in `content` with values loaded above.
+# Sed-special characters in the value (`&`, `\`, `|`) are escaped first.
+# Escaping the literal `\` is what protects against backreferences too:
+# a value of `\1` becomes `\\1` after the escape, which sed reads as a
+# literal backslash followed by `1` — not a backref. Bash 5.2+ builtin
+# substitution `${var//pat/repl}` would have its own `&`-as-match trap
+# that does not exist on bash 3.2 (macOS default), so sed is portable.
 resolve_placeholders() {
   local content="$1"
   local key
@@ -86,16 +91,17 @@ load_crewrig_config
 # explicitly at the bottom of the output frontmatter.
 
 # Returns the provenance YAML block ready to splice into a frontmatter, or
-# empty if the source has no provenance: block.
+# empty if `frontmatter` (already extracted) has no `provenance:` key.
+# Takes the frontmatter as input so callers can reuse a single extraction.
 provenance_block() {
-  local source="$1"
+  local frontmatter="$1"
   local has_prov
-  has_prov=$(extract_frontmatter "$source" | yq -r 'has("provenance")' 2>/dev/null || echo "false")
+  has_prov=$(printf '%s\n' "$frontmatter" | yq -r 'has("provenance")' 2>/dev/null || echo "false")
   if [ "$has_prov" != "true" ]; then
     return 0
   fi
   printf 'provenance:\n'
-  extract_frontmatter "$source" \
+  printf '%s\n' "$frontmatter" \
     | yq -r '.provenance | to_entries | .[] | "  " + .key + ": \"" + .value + "\""' 2>/dev/null
 }
 
@@ -106,8 +112,10 @@ provenance_block() {
 inject_provenance() {
   local content="$1"
   local source="$2"
+  local frontmatter
+  frontmatter=$(extract_frontmatter "$source")
   local prov
-  prov=$(provenance_block "$source")
+  prov=$(provenance_block "$frontmatter")
   if [ -z "$prov" ]; then
     printf '%s' "$content"
     return 0


### PR DESCRIPTION
First of three PRs implementing #41. Targets `release/crew-v0` (long-lived release branch); merges to `main` once PRs B and C land.

## How to read this PR?

Read in this order — each builds on the previous:

1. **`crewrig.config.toml`** — the new fork-config file at the repo root. Two keys: `canonical_repo` and `feedback_repo`.
2. **`scripts/build-components.sh`** — three additions and one drive-by:
   - `load_crewrig_config()` + `resolve_placeholders()` near the top: read the config, substitute `${UPPERCASED_KEY}` in any string.
   - `provenance_block()` + `inject_provenance()`: read a `provenance:` block from a source file's frontmatter, splice it into the output frontmatter before the closing `---`.
   - `check_or_write` now takes an optional source path (`$3`); if present, it injects the provenance and resolves placeholders before diffing/writing.
   - **Drive-by fix**: `TARGET="${1:-all}"` was capturing `--check` as the target, silently skipping every build branch and turning `--check` into a no-op. Replaced with explicit `TARGET="all"` + arg parsing.
3. **`community-config/FORMAT.md`** — new "Provenance & Forks" section documenting the schema, the resolver, and the forking workflow.
4. **`community-config/skills/ci-workflow-engineering/SKILL.md`** — smoke-test source: declares a provenance block with `${CANONICAL_REPO}` / `${FEEDBACK_REPO}` placeholders.
5. **`.gemini/skills/ci-workflow-engineering/SKILL.md`** + **`.claude/skills/ci-workflow-engineering/SKILL.md`** — regenerated outputs proving the round-trip: placeholders → resolved URLs.

## How to test this PR?

```bash
# Sanity: build with the default config (canonical = hcross/crewrig)
task build-components
grep canonical .gemini/skills/ci-workflow-engineering/SKILL.md
# Expect: canonical: "https://github.com/hcross/crewrig"

# Drift detection now actually works
sed -i.bak 's|hcross/crewrig|acme/crewrig-internal|g' crewrig.config.toml
task check-components
# Expect: DRIFT messages, exit non-zero
mv crewrig.config.toml.bak crewrig.config.toml

# Re-build returns to clean state
task build-components
task check-components
# Expect: "OK: All generated files match source.", exit 0
```

The `grep-anti-patterns` workflow added in #32/#40 also runs against `scripts/`; the new code stays clean against both Rule 1 and Rule 3 (verified locally).

## Detailed description (for agents)

### Files changed

**1. `crewrig.config.toml` (NEW)**

Two keys. Comments explain the canonical-vs-feedback split for forks. No nested sections — kept flat so a 30-line shell parser handles it without a TOML lib.

**2. `scripts/build-components.sh` (MODIFIED, +126/−7 lines)**

- `load_crewrig_config()`: reads `KEY = "value"` lines from the config, normalizes the key to uppercase, sets `CFG_<KEY>` shell variables and tracks `CFG_KEYS`. Bash 3.2-compatible (`printf -v` instead of associative arrays).
- `resolve_placeholders()`: walks `CFG_KEYS`, applies `sed s|\${KEY}|value|g` per key, escaping sed special chars in the value.
- `provenance_block()`: queries `yq` for the `provenance` subtree, returns a YAML block ready to splice (`provenance:` header + 2-space-indented `key: "value"` lines).
- `inject_provenance()`: pipes the content through `awk` to print the prov block before the second `---`. Uses a tempfile because BSD `awk` does not accept newlines in `-v var=...`.
- `check_or_write` now takes a third optional `$source` arg. When present, runs `inject_provenance` and `resolve_placeholders` on the content before the diff/write. Five of six call sites pass `$source` (the body-only Gemini agent output cannot carry frontmatter).
- Drive-by: `TARGET="${1:-all}"` → `TARGET="all"` with explanatory comment.

**3. `community-config/FORMAT.md` (MODIFIED, +57 lines)**

New "Provenance & Forks" section, placed between "Build Outputs" and "Parser Requirements". Covers the schema, placeholder resolution mechanics, the forking workflow, and the policy that components without a `provenance:` block build unchanged (no automatic backfill).

**4. `community-config/skills/ci-workflow-engineering/SKILL.md` (MODIFIED, +4 lines)**

Adds a `provenance:` block with placeholders. Body and `claude:` overrides untouched.

**5. `.gemini/...` + `.claude/...` (MODIFIED, +4 each)**

Regenerated outputs. Reviewers can verify by re-running `task build-components` — the diff against this PR should be empty.

### Out of scope

- Backfilling the existing components in `community-config/agents/`, `community-config/commands/`, etc. with provenance blocks. Will happen organically in PR B as new components ship with the block from day one.
- The `context:` block (project language / build tool / commit style) discussed in #41's design. Defer until a real fork demonstrates the need.
- Migration of `extension-skeleton/SKELETON_NAME` literals to the new placeholder syntax. Tracked in #44.

## Logbook

See #41 — will append PR A wrap-up there once this lands.