### PR TITLE
✨ PR C — Harness Curator implementation + smoke test

### DIFF
--- a/.claude/skills/harness-curator/SKILL.md
+++ b/.claude/skills/harness-curator/SKILL.md
@@ -40,119 +40,102 @@ for this skill, you are off-task.
 
 ## Operating mode
 
-### 1. Read the friction wing
+The heavy lifting (reading the wing, parsing payloads, clustering,
+composing MR bodies) is delegated to a bundled script — you run it,
+read the JSON it returns, and open MRs from there. This split exists
+because batch-reading the friction wing per-call through MCP would be
+a multi-thousand-call traversal; see `config/TOOLS.md` → *Carve-out
+for bundled skill/agent scripts* for the rationale.
 
-```text
-mempalace_search(
-  query="FRICTION:",
-  wing="harness-friction"
-)
+### 1. Run the curator script
+
+```bash
+task harness-curate -- --dry-run
+# or directly:
+bash scripts/harness-curate.sh --dry-run
 ```
 
-The friction wing is global, not project-scoped. A sweep returns
-frictions tagged across every project that uses crewrig-built agents.
-This is intentional — patterns repeat across forks and only become
-visible across them.
+The script walks `wing="harness-friction"` via the MemPalace Python
+library, parses every `FRICTION:` payload, clusters, and emits a JSON
+document on stdout:
 
-For each result, parse the payload (see `config/TOOLS.md` →
-*Friction Reporting* → *Payload schema*). Validate that the required
-fields (`writer_agent`, ≥1 `evidence:`) are present; skip malformed
-entries and note the count of skipped entries in the run summary.
+```json
+{
+  "stats": {
+    "total_drawers": 12,
+    "valid_frictions": 11,
+    "skipped_malformed": 1,
+    "clusters_formed": 4,
+    "clusters_above_threshold": 2,
+    "clusters_parked": 2,
+    "routing_failures": 0
+  },
+  "clusters": [
+    {
+      "cluster_key": "yq-merge",
+      "cluster_size": 3,
+      "target_repo": "https://github.com/hcross/crewrig",
+      "title": "Friction cluster: yq-merge (3 reports)",
+      "body": "<markdown>",
+      "branch_name": "harness/yq-merge-2026-05-10",
+      "frictions": [...]
+    }
+  ]
+}
+```
 
-### 2. Optional context
+### 2. Validate the output before opening anything
 
-After loading the frictions:
+Read the JSON. Check the stats — high `skipped_malformed` or
+`routing_failures` is a signal that the wing has rot, and you should
+investigate before opening MRs. Spot-check at least one body to make
+sure it reads sensibly.
 
-- Read recent open `logbook` issues on the canonical repo for context
-  the friction author may have referenced.
-- Follow `evidence:` pointers — fetch the file or URL when feasible.
-  This adds substance to the MR body and catches "evidence rot"
-  (broken pointers).
+### 3. Open the MRs
+
+Two paths, equivalent in outcome:
+
+- **Let the script do it**: `task harness-curate -- --apply`. The
+  script opens one MR per cluster via `gh pr create`, labelled
+  `harness-feedback`, on the branch named in the JSON.
+- **Open them yourself**: iterate the JSON, use the GitHub MCP (or
+  `gh`) per cluster. Use this path when you want to enrich the body
+  before opening (e.g. linking a recent `logbook` issue you noticed
+  while reviewing).
+
+Either way: **one MR per cluster**. Resist bundling — independent
+clusters deserve independent review.
+
+### 4. Threshold + routing rules (encoded in the script)
+
+The script applies these for you. Documented here so you can override
+via flags when the situation warrants:
+
+| Rule | Default | Override |
+|---|---|---|
+| Cluster size threshold | 2 | `--threshold N` |
+| Severity-`high` bypass | always promotes a singleton | (no override — by design) |
+| Target repo | most-frequent `canonical:` in cluster | `--target-repo <url>` for tests |
+| Cluster key | `subcategory:` if set, else `room` | (no override — wire-protocol) |
+
+A cluster with no resolvable `canonical:` and no `--target-repo`
+override counts as a *routing failure* — surfaced in the stats, not
+opened blind.
 
 `--deep` mode (sweep `wing="transcripts"` for unflagged friction
-patterns) is **out of V0 scope** — tracked in issue #43.
+patterns) is **out of V0 scope** — tracked in issue #43. Auto mode is
+tracked in issue #42.
 
-### 3. Cluster
+### 5. Run summary
 
-Cluster frictions by:
-
-1. **Primary key**: `subcategory` field if present.
-2. **Fallback**: `room` (one of the 5 categories).
-
-Threshold for proposing an MR per cluster:
-
-- **≥ 2 frictions** sharing the cluster key, OR
-- **≥ 1 friction with `severity: high`**.
-
-Singleton low/med-severity frictions stay in the wing; they may
-accumulate over time and cross the threshold on a later run.
-
-### 4. Pick the target repo per cluster
-
-For each cluster, determine the MR target from the offending
-component's `provenance:` block:
-
-- `feedback` URL if present.
-- Otherwise `canonical`.
-- If the cluster spans multiple components with conflicting
-  provenance, pick the most-frequent target and list the others as
-  "Also applies to" in the MR body.
-
-If no friction in the cluster carries `canonical:` and the offending
-component cannot be inferred from `evidence:`, surface this as a
-"could not route" entry in the run summary — do not open a blind MR.
-
-### 5. Compose the MR body
-
-```markdown
-## Friction cluster: <cluster key>
-
-<Number> frictions tagged across <date range>.
-
-### Pattern
-
-<One paragraph: the common thread across the frictions.>
-
-### Frictions
-
-1. **<friction-1 title>**
-   - Reported by: <writer_agent>
-   - Severity: <severity>
-   - Evidence: <evidence pointers>
-   - Suggestion (from reporter): <suggestion if any>
-
-2. <repeat for each friction in cluster>
-
-### Suggested resolution
-
-<Synthesis of the suggestions, plus the Curator's own framing if the
-suggestions agree or diverge. Keep it short — the human reader will
-write the actual fix.>
-
-### Out of scope
-
-<What this MR does *not* attempt — keeps the diff focused.>
-```
-
-### 6. Open the MR
-
-Use the GitHub MCP server (preferred) or `gh` CLI:
-
-- One MR per cluster. Resist bundling — clusters that are independent
-  should be reviewed independently.
-- Branch naming: `harness/<cluster-key>-<date>`.
-- Label: `harness-feedback`.
-- Link the MR back to the source frictions only by reference (drawer
-  IDs in the MR body) — do not paste full payloads.
-
-### 7. Run summary
-
-After opening MRs, post a brief run summary to the user:
+After applying, post a brief run summary to the user:
 
 - Frictions read / skipped (malformed).
-- Clusters formed / clusters that hit threshold / clusters parked.
-- MRs opened (with links).
-- Routing failures (clusters with no resolvable provenance).
+- Clusters formed / above threshold / parked.
+- MRs opened (with links) / routing failures.
+
+The summary is the primary signal that the loop ran. Even a zero-MR
+run is worth reporting — it tells the user the wing is healthy.
 
 ## Output expectations
 

--- a/.gemini/skills/harness-curator/SKILL.md
+++ b/.gemini/skills/harness-curator/SKILL.md
@@ -34,119 +34,102 @@ for this skill, you are off-task.
 
 ## Operating mode
 
-### 1. Read the friction wing
+The heavy lifting (reading the wing, parsing payloads, clustering,
+composing MR bodies) is delegated to a bundled script — you run it,
+read the JSON it returns, and open MRs from there. This split exists
+because batch-reading the friction wing per-call through MCP would be
+a multi-thousand-call traversal; see `config/TOOLS.md` → *Carve-out
+for bundled skill/agent scripts* for the rationale.
 
-```text
-mempalace_search(
-  query="FRICTION:",
-  wing="harness-friction"
-)
+### 1. Run the curator script
+
+```bash
+task harness-curate -- --dry-run
+# or directly:
+bash scripts/harness-curate.sh --dry-run
 ```
 
-The friction wing is global, not project-scoped. A sweep returns
-frictions tagged across every project that uses crewrig-built agents.
-This is intentional — patterns repeat across forks and only become
-visible across them.
+The script walks `wing="harness-friction"` via the MemPalace Python
+library, parses every `FRICTION:` payload, clusters, and emits a JSON
+document on stdout:
 
-For each result, parse the payload (see `config/TOOLS.md` →
-*Friction Reporting* → *Payload schema*). Validate that the required
-fields (`writer_agent`, ≥1 `evidence:`) are present; skip malformed
-entries and note the count of skipped entries in the run summary.
+```json
+{
+  "stats": {
+    "total_drawers": 12,
+    "valid_frictions": 11,
+    "skipped_malformed": 1,
+    "clusters_formed": 4,
+    "clusters_above_threshold": 2,
+    "clusters_parked": 2,
+    "routing_failures": 0
+  },
+  "clusters": [
+    {
+      "cluster_key": "yq-merge",
+      "cluster_size": 3,
+      "target_repo": "https://github.com/hcross/crewrig",
+      "title": "Friction cluster: yq-merge (3 reports)",
+      "body": "<markdown>",
+      "branch_name": "harness/yq-merge-2026-05-10",
+      "frictions": [...]
+    }
+  ]
+}
+```
 
-### 2. Optional context
+### 2. Validate the output before opening anything
 
-After loading the frictions:
+Read the JSON. Check the stats — high `skipped_malformed` or
+`routing_failures` is a signal that the wing has rot, and you should
+investigate before opening MRs. Spot-check at least one body to make
+sure it reads sensibly.
 
-- Read recent open `logbook` issues on the canonical repo for context
-  the friction author may have referenced.
-- Follow `evidence:` pointers — fetch the file or URL when feasible.
-  This adds substance to the MR body and catches "evidence rot"
-  (broken pointers).
+### 3. Open the MRs
+
+Two paths, equivalent in outcome:
+
+- **Let the script do it**: `task harness-curate -- --apply`. The
+  script opens one MR per cluster via `gh pr create`, labelled
+  `harness-feedback`, on the branch named in the JSON.
+- **Open them yourself**: iterate the JSON, use the GitHub MCP (or
+  `gh`) per cluster. Use this path when you want to enrich the body
+  before opening (e.g. linking a recent `logbook` issue you noticed
+  while reviewing).
+
+Either way: **one MR per cluster**. Resist bundling — independent
+clusters deserve independent review.
+
+### 4. Threshold + routing rules (encoded in the script)
+
+The script applies these for you. Documented here so you can override
+via flags when the situation warrants:
+
+| Rule | Default | Override |
+|---|---|---|
+| Cluster size threshold | 2 | `--threshold N` |
+| Severity-`high` bypass | always promotes a singleton | (no override — by design) |
+| Target repo | most-frequent `canonical:` in cluster | `--target-repo <url>` for tests |
+| Cluster key | `subcategory:` if set, else `room` | (no override — wire-protocol) |
+
+A cluster with no resolvable `canonical:` and no `--target-repo`
+override counts as a *routing failure* — surfaced in the stats, not
+opened blind.
 
 `--deep` mode (sweep `wing="transcripts"` for unflagged friction
-patterns) is **out of V0 scope** — tracked in issue #43.
+patterns) is **out of V0 scope** — tracked in issue #43. Auto mode is
+tracked in issue #42.
 
-### 3. Cluster
+### 5. Run summary
 
-Cluster frictions by:
-
-1. **Primary key**: `subcategory` field if present.
-2. **Fallback**: `room` (one of the 5 categories).
-
-Threshold for proposing an MR per cluster:
-
-- **≥ 2 frictions** sharing the cluster key, OR
-- **≥ 1 friction with `severity: high`**.
-
-Singleton low/med-severity frictions stay in the wing; they may
-accumulate over time and cross the threshold on a later run.
-
-### 4. Pick the target repo per cluster
-
-For each cluster, determine the MR target from the offending
-component's `provenance:` block:
-
-- `feedback` URL if present.
-- Otherwise `canonical`.
-- If the cluster spans multiple components with conflicting
-  provenance, pick the most-frequent target and list the others as
-  "Also applies to" in the MR body.
-
-If no friction in the cluster carries `canonical:` and the offending
-component cannot be inferred from `evidence:`, surface this as a
-"could not route" entry in the run summary — do not open a blind MR.
-
-### 5. Compose the MR body
-
-```markdown
-## Friction cluster: <cluster key>
-
-<Number> frictions tagged across <date range>.
-
-### Pattern
-
-<One paragraph: the common thread across the frictions.>
-
-### Frictions
-
-1. **<friction-1 title>**
-   - Reported by: <writer_agent>
-   - Severity: <severity>
-   - Evidence: <evidence pointers>
-   - Suggestion (from reporter): <suggestion if any>
-
-2. <repeat for each friction in cluster>
-
-### Suggested resolution
-
-<Synthesis of the suggestions, plus the Curator's own framing if the
-suggestions agree or diverge. Keep it short — the human reader will
-write the actual fix.>
-
-### Out of scope
-
-<What this MR does *not* attempt — keeps the diff focused.>
-```
-
-### 6. Open the MR
-
-Use the GitHub MCP server (preferred) or `gh` CLI:
-
-- One MR per cluster. Resist bundling — clusters that are independent
-  should be reviewed independently.
-- Branch naming: `harness/<cluster-key>-<date>`.
-- Label: `harness-feedback`.
-- Link the MR back to the source frictions only by reference (drawer
-  IDs in the MR body) — do not paste full payloads.
-
-### 7. Run summary
-
-After opening MRs, post a brief run summary to the user:
+After applying, post a brief run summary to the user:
 
 - Frictions read / skipped (malformed).
-- Clusters formed / clusters that hit threshold / clusters parked.
-- MRs opened (with links).
-- Routing failures (clusters with no resolvable provenance).
+- Clusters formed / above threshold / parked.
+- MRs opened (with links) / routing failures.
+
+The summary is the primary signal that the loop ran. Even a zero-MR
+run is worth reporting — it tells the user the wing is healthy.
 
 ## Output expectations
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,3 +52,14 @@ jobs:
 
       - name: Lint Markdown files
         run: markdownlint "**/*.md" --ignore node_modules --ignore extension-skeleton --ignore communication
+
+  test-harness-curate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Smoke-test harness curator
+        run: bash tests/harness/test-curate.sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -176,3 +176,13 @@ tasks:
   prune-transcripts:
     desc: "Prune old transcripts from MemPalace (task prune-transcripts -- --days 30 [--apply])"
     cmd: bash {{.REPO_DIR}}/scripts/prune-transcripts.sh {{.CLI_ARGS}}
+
+  # --- Harness Feedback Loop ---
+
+  harness-curate:
+    desc: "Run the Harness Curator (task harness-curate -- [--apply | --from-stdin])"
+    cmd: bash {{.REPO_DIR}}/scripts/harness-curate.sh {{.CLI_ARGS}}
+
+  test-harness-curate:
+    desc: "Smoke-test the Harness Curator against the bundled fixture"
+    cmd: bash {{.REPO_DIR}}/tests/harness/test-curate.sh

--- a/community-config/skills/harness-curator/SKILL.md
+++ b/community-config/skills/harness-curator/SKILL.md
@@ -44,119 +44,102 @@ for this skill, you are off-task.
 
 ## Operating mode
 
-### 1. Read the friction wing
+The heavy lifting (reading the wing, parsing payloads, clustering,
+composing MR bodies) is delegated to a bundled script — you run it,
+read the JSON it returns, and open MRs from there. This split exists
+because batch-reading the friction wing per-call through MCP would be
+a multi-thousand-call traversal; see `config/TOOLS.md` → *Carve-out
+for bundled skill/agent scripts* for the rationale.
 
-```text
-mempalace_search(
-  query="FRICTION:",
-  wing="harness-friction"
-)
+### 1. Run the curator script
+
+```bash
+task harness-curate -- --dry-run
+# or directly:
+bash scripts/harness-curate.sh --dry-run
 ```
 
-The friction wing is global, not project-scoped. A sweep returns
-frictions tagged across every project that uses crewrig-built agents.
-This is intentional — patterns repeat across forks and only become
-visible across them.
+The script walks `wing="harness-friction"` via the MemPalace Python
+library, parses every `FRICTION:` payload, clusters, and emits a JSON
+document on stdout:
 
-For each result, parse the payload (see `config/TOOLS.md` →
-*Friction Reporting* → *Payload schema*). Validate that the required
-fields (`writer_agent`, ≥1 `evidence:`) are present; skip malformed
-entries and note the count of skipped entries in the run summary.
+```json
+{
+  "stats": {
+    "total_drawers": 12,
+    "valid_frictions": 11,
+    "skipped_malformed": 1,
+    "clusters_formed": 4,
+    "clusters_above_threshold": 2,
+    "clusters_parked": 2,
+    "routing_failures": 0
+  },
+  "clusters": [
+    {
+      "cluster_key": "yq-merge",
+      "cluster_size": 3,
+      "target_repo": "https://github.com/hcross/crewrig",
+      "title": "Friction cluster: yq-merge (3 reports)",
+      "body": "<markdown>",
+      "branch_name": "harness/yq-merge-2026-05-10",
+      "frictions": [...]
+    }
+  ]
+}
+```
 
-### 2. Optional context
+### 2. Validate the output before opening anything
 
-After loading the frictions:
+Read the JSON. Check the stats — high `skipped_malformed` or
+`routing_failures` is a signal that the wing has rot, and you should
+investigate before opening MRs. Spot-check at least one body to make
+sure it reads sensibly.
 
-- Read recent open `logbook` issues on the canonical repo for context
-  the friction author may have referenced.
-- Follow `evidence:` pointers — fetch the file or URL when feasible.
-  This adds substance to the MR body and catches "evidence rot"
-  (broken pointers).
+### 3. Open the MRs
+
+Two paths, equivalent in outcome:
+
+- **Let the script do it**: `task harness-curate -- --apply`. The
+  script opens one MR per cluster via `gh pr create`, labelled
+  `harness-feedback`, on the branch named in the JSON.
+- **Open them yourself**: iterate the JSON, use the GitHub MCP (or
+  `gh`) per cluster. Use this path when you want to enrich the body
+  before opening (e.g. linking a recent `logbook` issue you noticed
+  while reviewing).
+
+Either way: **one MR per cluster**. Resist bundling — independent
+clusters deserve independent review.
+
+### 4. Threshold + routing rules (encoded in the script)
+
+The script applies these for you. Documented here so you can override
+via flags when the situation warrants:
+
+| Rule | Default | Override |
+|---|---|---|
+| Cluster size threshold | 2 | `--threshold N` |
+| Severity-`high` bypass | always promotes a singleton | (no override — by design) |
+| Target repo | most-frequent `canonical:` in cluster | `--target-repo <url>` for tests |
+| Cluster key | `subcategory:` if set, else `room` | (no override — wire-protocol) |
+
+A cluster with no resolvable `canonical:` and no `--target-repo`
+override counts as a *routing failure* — surfaced in the stats, not
+opened blind.
 
 `--deep` mode (sweep `wing="transcripts"` for unflagged friction
-patterns) is **out of V0 scope** — tracked in issue #43.
+patterns) is **out of V0 scope** — tracked in issue #43. Auto mode is
+tracked in issue #42.
 
-### 3. Cluster
+### 5. Run summary
 
-Cluster frictions by:
-
-1. **Primary key**: `subcategory` field if present.
-2. **Fallback**: `room` (one of the 5 categories).
-
-Threshold for proposing an MR per cluster:
-
-- **≥ 2 frictions** sharing the cluster key, OR
-- **≥ 1 friction with `severity: high`**.
-
-Singleton low/med-severity frictions stay in the wing; they may
-accumulate over time and cross the threshold on a later run.
-
-### 4. Pick the target repo per cluster
-
-For each cluster, determine the MR target from the offending
-component's `provenance:` block:
-
-- `feedback` URL if present.
-- Otherwise `canonical`.
-- If the cluster spans multiple components with conflicting
-  provenance, pick the most-frequent target and list the others as
-  "Also applies to" in the MR body.
-
-If no friction in the cluster carries `canonical:` and the offending
-component cannot be inferred from `evidence:`, surface this as a
-"could not route" entry in the run summary — do not open a blind MR.
-
-### 5. Compose the MR body
-
-```markdown
-## Friction cluster: <cluster key>
-
-<Number> frictions tagged across <date range>.
-
-### Pattern
-
-<One paragraph: the common thread across the frictions.>
-
-### Frictions
-
-1. **<friction-1 title>**
-   - Reported by: <writer_agent>
-   - Severity: <severity>
-   - Evidence: <evidence pointers>
-   - Suggestion (from reporter): <suggestion if any>
-
-2. <repeat for each friction in cluster>
-
-### Suggested resolution
-
-<Synthesis of the suggestions, plus the Curator's own framing if the
-suggestions agree or diverge. Keep it short — the human reader will
-write the actual fix.>
-
-### Out of scope
-
-<What this MR does *not* attempt — keeps the diff focused.>
-```
-
-### 6. Open the MR
-
-Use the GitHub MCP server (preferred) or `gh` CLI:
-
-- One MR per cluster. Resist bundling — clusters that are independent
-  should be reviewed independently.
-- Branch naming: `harness/<cluster-key>-<date>`.
-- Label: `harness-feedback`.
-- Link the MR back to the source frictions only by reference (drawer
-  IDs in the MR body) — do not paste full payloads.
-
-### 7. Run summary
-
-After opening MRs, post a brief run summary to the user:
+After applying, post a brief run summary to the user:
 
 - Frictions read / skipped (malformed).
-- Clusters formed / clusters that hit threshold / clusters parked.
-- MRs opened (with links).
-- Routing failures (clusters with no resolvable provenance).
+- Clusters formed / above threshold / parked.
+- MRs opened (with links) / routing failures.
+
+The summary is the primary signal that the loop ran. Even a zero-MR
+run is worth reporting — it tells the user the wing is healthy.
 
 ## Output expectations
 

--- a/config/TOOLS.md
+++ b/config/TOOLS.md
@@ -441,13 +441,18 @@ suggestion: <free-form fix idea, optional but encouraged>
 
 #### Field semantics
 
-- `writer_agent` — same convention as the task-handoff drawer. Lets the
-  Curator attribute clusters and lets the user trace who hit what.
+- `writer_agent` — required, **non-empty**. Same convention as the
+  task-handoff drawer. Lets the Curator attribute clusters and lets the
+  user trace who hit what. An empty value is treated as malformed and
+  the drawer is skipped.
 - `subcategory` — free-form clustering key. Frictions sharing a
   `subcategory` get bundled into the same MR by default.
 - `evidence` — at least one entry is required. Path to the file, URL of
   the failing CI run, link to the transcript line, or a verbatim
-  snippet. Without evidence the report is unactionable.
+  snippet. Without evidence the report is unactionable. The schema
+  above shows the canonical list form; a single inline value
+  (`evidence: <path-or-url>` on one line) is also accepted as a
+  one-entry list — useful when the friction has a single pointer.
 - `canonical` — when set, prefer the value of the offending component's
   own `provenance.canonical` block. Hand-typing a different URL drifts
   the friction away from the component the Curator should route the MR

--- a/config/TOOLS.md
+++ b/config/TOOLS.md
@@ -55,18 +55,45 @@ MemPalace is the unified persistent memory system, replacing the former
 Knowledge Graph Memory and Deep Memory servers. It provides palace-based
 storage, a temporal knowledge graph, semantic search, and an agent diary.
 
-> **MCP-only access.** Every MemPalace operation in this document
-> (`mempalace_status`, `mempalace_search`, `mempalace_add_drawer`,
-> `mempalace_update_drawer`, `mempalace_diary_*`, `mempalace_kg_*`, etc.)
-> is an **MCP tool call** routed through the registered `mempalace` MCP
-> server. **Never** invoke a `mempalace …` shell command via the Bash
-> tool. The `mempalace` CLI binary on `$PATH` exists for human admin
-> tasks (`init`, `migrate`, debug); calling it from an agent bypasses
-> the MCP server's session context, file locking, audit trail, and
-> protocol negotiation, and produces drawers the rest of the agent
-> network cannot see. If a procedure cannot be expressed via the MCP
-> tools listed in *MCP Tools Reference*, ask the user — do not reach
-> for the CLI as a workaround.
+> **MCP-only access from the agent prompt.** Every MemPalace operation
+> in this document (`mempalace_status`, `mempalace_search`,
+> `mempalace_add_drawer`, `mempalace_update_drawer`, `mempalace_diary_*`,
+> `mempalace_kg_*`, etc.) invoked **directly from an agent's reasoning
+> loop** is an **MCP tool call** routed through the registered
+> `mempalace` MCP server. **Never** invoke a `mempalace …` shell command
+> ad-hoc via the Bash tool. The `mempalace` CLI binary on `$PATH` exists
+> for human admin tasks (`init`, `migrate`, debug); calling it
+> opportunistically from an agent bypasses the MCP server's session
+> context, file locking, audit trail, and protocol negotiation, and
+> produces drawers the rest of the agent network cannot see. If a
+> procedure cannot be expressed via the MCP tools listed in *MCP Tools
+> Reference*, ask the user — do not reach for the CLI as a workaround.
+>
+> **Carve-out for bundled skill/agent scripts.** A skill or agent may
+> ship a versioned, source-controlled script that walks MemPalace
+> directly (e.g. via `from mempalace import …`) when the workload would
+> be infeasible through MCP alone — for instance, batch-reading
+> thousands of drawers, which a per-call MCP loop turns into a runtime
+> and token disaster. Such a script is allowed when **all** of these
+> hold:
+>
+> 1. It is checked into the repository alongside the skill/agent that
+>    invokes it (auditability replaces the per-call audit trail).
+> 2. It uses the MemPalace **Python library**, not the shell CLI binary,
+>    so it inherits the same locking and schema guarantees as the MCP
+>    server.
+> 3. It is **read-mostly**; any write path must justify why MCP
+>    `mempalace_add_drawer` / `mempalace_update_drawer` cannot be used
+>    instead, in a comment at the call site.
+> 4. The agent that invokes the script remains the agent of record —
+>    the script is a sub-tool, not a substitute for the agent's MemPalace
+>    discipline (Memory Activation Protocol still applies at session
+>    start).
+>
+> The Harness Curator (`community-config/skills/harness-curator/`) is
+> the canonical user of this carve-out: it batch-reads the
+> `harness-friction` wing, which a per-drawer MCP loop would turn into
+> a multi-thousand-call traversal.
 
 ### Palace Structure Conventions
 

--- a/scripts/harness-curate.sh
+++ b/scripts/harness-curate.sh
@@ -64,6 +64,9 @@ if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]] || [ "$THRESHOLD" -lt 1 ]; then
 fi
 
 # --- Dependencies ---
+# Always returns 0 — the function's job is to *resolve* a Python path; the
+# caller does not branch on the exit code. A non-zero return here would
+# trigger `set -e` on the calling assignment when the pipx path is absent.
 auto_detect_mempalace_python() {
   if command -v pipx >/dev/null 2>&1; then
     local pipx_venv
@@ -74,7 +77,6 @@ auto_detect_mempalace_python() {
     fi
   fi
   echo "python3"
-  return 1
 }
 
 MEMPALACE_PYTHON="${MEMPALACE_PYTHON:-$(auto_detect_mempalace_python)}"

--- a/scripts/harness-curate.sh
+++ b/scripts/harness-curate.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# harness-curate.sh — Harness Curator entry point
+#
+# Reads friction reports from MemPalace `wing="harness-friction"` (or from
+# stdin in test mode), clusters them by subcategory/room, composes MR bodies,
+# and either prints the result as JSON (`--dry-run`, default) or opens MRs
+# via `gh` (`--apply`).
+#
+# Usage:
+#   bash scripts/harness-curate.sh [--dry-run | --apply]
+#                                  [--from-stdin]
+#                                  [--target-repo <url>]
+#                                  [--threshold <n>]
+#
+# Options:
+#   --dry-run        Output JSON of clusters that would become MRs (default).
+#   --apply          Open MRs via `gh pr create`. Requires gh authenticated.
+#   --from-stdin     Read frictions JSON list from stdin instead of MemPalace.
+#                    For unit tests and dry-runs without a live wing.
+#   --target-repo    Force a single MR target repo (overrides per-friction
+#                    provenance routing). For tests / single-fork curation.
+#   --threshold      Minimum cluster size to propose an MR (default: 2).
+#                    Severity-`high` frictions bypass this and always cluster.
+#
+# Environment:
+#   MEMPALACE_PYTHON Python binary with `mempalace` installed (auto-detected
+#                    from pipx if unset).
+#
+# This script uses the bundled-skill carve-out documented in `config/TOOLS.md`:
+# it walks MemPalace via `from mempalace.mcp_server import tool_list_drawers`
+# rather than per-call MCP because batch-reading the friction wing through
+# MCP would be a multi-thousand-call traversal. Read-only path; any future
+# write goes through MCP.
+
+set -euo pipefail
+
+DRY_RUN=true
+FROM_STDIN=false
+TARGET_REPO=""
+THRESHOLD=2
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)        DRY_RUN=true; shift ;;
+    --apply)          DRY_RUN=false; shift ;;
+    --from-stdin)     FROM_STDIN=true; shift ;;
+    --target-repo)    TARGET_REPO="$2"; shift 2 ;;
+    --threshold)      THRESHOLD="$2"; shift 2 ;;
+    --help|-h)
+      sed -n '2,30p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Run '$0 --help' for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]] || [ "$THRESHOLD" -lt 1 ]; then
+  echo "Error: --threshold must be a positive integer" >&2
+  exit 1
+fi
+
+# --- Dependencies ---
+auto_detect_mempalace_python() {
+  if command -v pipx >/dev/null 2>&1; then
+    local pipx_venv
+    pipx_venv=$(pipx environment --value PIPX_HOME 2>/dev/null)/venvs/mempalace
+    if [ -d "$pipx_venv" ]; then
+      echo "$pipx_venv/bin/python3"
+      return 0
+    fi
+  fi
+  echo "python3"
+  return 1
+}
+
+MEMPALACE_PYTHON="${MEMPALACE_PYTHON:-$(auto_detect_mempalace_python)}"
+
+# --from-stdin mode does not need mempalace, but the script must still find a
+# usable Python. Fall back to system python3 if mempalace path is unusable.
+if [ "$FROM_STDIN" = true ] && ! command -v "$MEMPALACE_PYTHON" >/dev/null 2>&1; then
+  MEMPALACE_PYTHON="python3"
+fi
+
+command -v "$MEMPALACE_PYTHON" >/dev/null 2>&1 || {
+  echo "Error: $MEMPALACE_PYTHON not found" >&2
+  echo "Install MemPalace via pipx: pipx install 'mempalace>=3.3.3,<3.4'" >&2
+  exit 2
+}
+
+# --- Run the curator ---
+TODAY=$(date +%Y-%m-%d)
+
+# Read stdin into a tempfile if applicable so the python heredoc can re-open
+# it; passing stdin straight to the heredoc works on bash but fails when the
+# script is sourced or run under unusual launchers.
+STDIN_FILE=""
+if [ "$FROM_STDIN" = true ]; then
+  STDIN_FILE=$(mktemp -t crewrig-curate.XXXXXX)
+  trap 'rm -f "$STDIN_FILE"' EXIT
+  cat > "$STDIN_FILE"
+fi
+
+CURATE_OUT=$(env \
+  FRICTION_WING="harness-friction" \
+  TODAY="$TODAY" \
+  THRESHOLD="$THRESHOLD" \
+  TARGET_REPO_OVERRIDE="$TARGET_REPO" \
+  FROM_STDIN_FILE="$STDIN_FILE" \
+  "$MEMPALACE_PYTHON" "$(dirname "$0")/lib/harness_curate.py")
+
+# --- Output / apply ---
+if [ "$DRY_RUN" = true ]; then
+  printf '%s\n' "$CURATE_OUT"
+  exit 0
+fi
+
+# --apply: open MRs via gh. Requires gh authenticated.
+command -v gh >/dev/null 2>&1 || {
+  echo "Error: --apply requires the 'gh' CLI to be installed and authenticated." >&2
+  exit 3
+}
+
+# Parse JSON and open one MR per cluster.
+echo "$CURATE_OUT" | "$MEMPALACE_PYTHON" -c '
+import json, os, subprocess, sys
+
+data = json.load(sys.stdin)
+clusters = data.get("clusters", [])
+if not clusters:
+    print("No clusters above threshold; no MRs to open.")
+    sys.exit(0)
+
+opened = []
+failures = []
+for c in clusters:
+    target = c["target_repo"]
+    title = c["title"]
+    body = c["body"]
+    branch = c["branch_name"]
+    print(f"--- Opening MR against {target}: {title}")
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "create",
+             "--repo", target.replace("https://github.com/", ""),
+             "--title", title,
+             "--body", body,
+             "--head", branch,
+             "--label", "harness-feedback"],
+            check=True, capture_output=True, text=True,
+        )
+        opened.append({"cluster": c["cluster_key"], "url": result.stdout.strip()})
+    except subprocess.CalledProcessError as e:
+        failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
+
+print()
+print(f"Opened: {len(opened)} MR(s)")
+for o in opened:
+    print(f"  - {o[\"cluster\"]}: {o[\"url\"]}")
+if failures:
+    print(f"Failures: {len(failures)}", file=sys.stderr)
+    for f in failures:
+        print(f"  - {f[\"cluster\"]}: {f[\"error\"]}", file=sys.stderr)
+    sys.exit(4)
+'

--- a/scripts/lib/harness_curate.py
+++ b/scripts/lib/harness_curate.py
@@ -144,9 +144,15 @@ def read_from_stdin_file() -> List[Dict[str, Any]]:
 
 
 def read_from_mempalace() -> List[Dict[str, Any]]:
-    """Walk wing=WING via the in-process mempalace API. Read-only."""
+    """Walk wing=WING via the in-process mempalace API. Read-only.
+
+    `tool_list_drawers` returns drawer stubs with `content_preview`
+    (truncated), not the full payload. We follow up with
+    `tool_get_drawer` per ID to fetch the full content and the
+    `metadata.filed_at` timestamp used for the MR body's date range.
+    """
     try:
-        from mempalace.mcp_server import tool_list_drawers
+        from mempalace.mcp_server import tool_get_drawer, tool_list_drawers
     except ImportError as e:
         print(
             f"Error: failed to import mempalace ({e}). "
@@ -162,7 +168,17 @@ def read_from_mempalace() -> List[Dict[str, Any]]:
         batch = page.get("drawers", [])
         if not batch:
             break
-        drawers.extend(batch)
+        for stub in batch:
+            did = stub.get("drawer_id")
+            if not did:
+                continue
+            full = tool_get_drawer(drawer_id=did)
+            drawers.append({
+                "drawer_id": did,
+                "room": full.get("room", "") or stub.get("room", ""),
+                "content": full.get("content", ""),
+                "filed_at": (full.get("metadata") or {}).get("filed_at", ""),
+            })
         if len(batch) < PAGE_SIZE:
             break  # last (partial) page reached
         offset += PAGE_SIZE
@@ -182,15 +198,17 @@ def cluster_key_for(friction: Dict[str, Any], room: str) -> str:
 
 
 def cluster_frictions(
-    parsed: List[Tuple[Dict[str, Any], str]],
+    parsed: List[Tuple[Dict[str, Any], str, str]],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Group parsed frictions by cluster key. Each value entry stores the
-    friction with its room glued in for downstream traceability."""
+    friction with its room and filed_at glued in for downstream
+    traceability and for date-range computation in the MR body."""
     clusters: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
-    for friction, room in parsed:
+    for friction, room, filed_at in parsed:
         key = cluster_key_for(friction, room)
         enriched = dict(friction)
         enriched["_room"] = room
+        enriched["_filed_at"] = filed_at
         clusters[key].append(enriched)
     return dict(clusters)
 
@@ -233,6 +251,25 @@ def pick_target_repo(cluster: List[Dict[str, Any]]) -> Optional[str]:
 # --- MR body composition --------------------------------------------------
 
 
+def cluster_date_range(cluster: List[Dict[str, Any]]) -> str:
+    """Compute a "from–to" date range from `_filed_at` timestamps.
+    Returns an empty string when no friction in the cluster carries a
+    timestamp (e.g. test fixture without metadata)."""
+    dates = []
+    for f in cluster:
+        ts = f.get("_filed_at", "")
+        if not ts:
+            continue
+        # filed_at is ISO 8601 (`2026-04-29T00:16:09.949576`); keep date.
+        dates.append(ts.split("T", 1)[0])
+    if not dates:
+        return ""
+    dates.sort()
+    if dates[0] == dates[-1]:
+        return dates[0]
+    return f"{dates[0]} → {dates[-1]}"
+
+
 def compose_body(
     cluster_key: str,
     cluster: List[Dict[str, Any]],
@@ -244,9 +281,11 @@ def compose_body(
     lines: List[str] = []
     lines.append(f"## Friction cluster: `{cluster_key}`")
     lines.append("")
+    date_range = cluster_date_range(cluster)
+    when = f" ({date_range})" if date_range else ""
     lines.append(
         f"{size} friction{'s' if size != 1 else ''} tagged across the "
-        f"`harness-friction` wing. Routed to `{target_repo}`."
+        f"`harness-friction` wing{when}. Routed to `{target_repo}`."
     )
     lines.append("")
     # Pattern paragraph: leave room for human / future LLM enrichment in V0
@@ -306,9 +345,13 @@ def compose_body(
 
 
 def safe_slug(s: str) -> str:
-    """Slugify a cluster key for use in a branch name."""
+    """Slugify a cluster key for use in a branch name. Truncated to
+    60 characters to stay under common Git refname limits and GitHub's
+    branch-name length checks; verbose subcategories survive in the MR
+    title and body, just not in the branch name."""
     s = re.sub(r"[^a-zA-Z0-9._-]+", "-", s).strip("-")
-    return s.lower() or "unknown"
+    s = s.lower() or "unknown"
+    return s[:60].rstrip("-") or "unknown"
 
 
 def main() -> int:
@@ -331,15 +374,16 @@ def main() -> int:
         "routing_failures": 0,
     }
 
-    parsed: List[Tuple[Dict[str, Any], str]] = []
+    parsed: List[Tuple[Dict[str, Any], str, str]] = []
     for drawer in drawers:
         content = drawer.get("content", "")
         room = drawer.get("room", "")
+        filed_at = drawer.get("filed_at", "")
         friction = parse_friction(content)
         if friction is None:
             stats["skipped_malformed"] += 1
             continue
-        parsed.append((friction, room))
+        parsed.append((friction, room, filed_at))
         stats["valid_frictions"] += 1
 
     clusters = cluster_frictions(parsed)

--- a/scripts/lib/harness_curate.py
+++ b/scripts/lib/harness_curate.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""harness_curate — Curator backend.
+
+Reads friction reports from MemPalace ``wing="harness-friction"`` (or from
+stdin in test mode), parses the ``FRICTION:`` payload schema documented in
+``config/TOOLS.md``, clusters them, composes MR bodies, and emits a single
+JSON document on stdout.
+
+Read-only against MemPalace. Writes — if ever needed — flow through MCP on
+the agent side, not from this script.
+
+Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
+
+    {
+      "stats": {
+        "total_drawers": int,
+        "valid_frictions": int,
+        "skipped_malformed": int,
+        "clusters_formed": int,
+        "clusters_above_threshold": int,
+        "clusters_parked": int,
+        "routing_failures": int
+      },
+      "clusters": [
+        {
+          "cluster_key": str,
+          "cluster_size": int,
+          "target_repo": str,
+          "title": str,
+          "body": str,
+          "branch_name": str,
+          "frictions": [...]
+        }
+      ]
+    }
+
+Environment variables (set by the bash wrapper):
+
+* ``FRICTION_WING`` — wing name to read from (default ``harness-friction``).
+* ``TODAY`` — date string for branch naming (``YYYY-MM-DD``).
+* ``THRESHOLD`` — minimum cluster size to propose an MR.
+* ``TARGET_REPO_OVERRIDE`` — force a single MR target (test mode).
+* ``FROM_STDIN_FILE`` — path to a JSON file with a list of fake drawers,
+  used for ``--from-stdin``. Empty when reading from MemPalace.
+"""
+
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Tuple
+
+# --- Configuration from environment ---------------------------------------
+
+WING = os.environ.get("FRICTION_WING", "harness-friction")
+TODAY = os.environ.get("TODAY", "")
+THRESHOLD = int(os.environ.get("THRESHOLD", "2"))
+TARGET_OVERRIDE = os.environ.get("TARGET_REPO_OVERRIDE", "").strip()
+STDIN_FILE = os.environ.get("FROM_STDIN_FILE", "").strip()
+
+# Keep the page size aligned with prune-transcripts.sh: 100 is the sweet spot
+# between MCP roundtrips and per-call payload size.
+PAGE_SIZE = 100
+MAX_TOTAL_DRAWERS = 50000  # safety cap, identical rationale to prune script
+
+
+# --- FRICTION payload parser ----------------------------------------------
+
+# Title line is fixed: ``FRICTION: <free-form title>``.
+TITLE_RE = re.compile(r"^FRICTION:\s*(.+)$")
+# Keys are lowercase identifiers; values may be empty.
+KV_RE = re.compile(r"^([a-z_][a-z0-9_]*):\s*(.*)$")
+# Evidence entries are ``  - <value>`` indented list items.
+LIST_RE = re.compile(r"^\s*-\s+(.+)$")
+
+
+def parse_friction(content: str) -> Optional[Dict[str, Any]]:
+    """Parse one FRICTION: payload. Return None if required fields are
+    missing — the caller treats None as "skip as malformed"."""
+    if not content:
+        return None
+    lines = content.splitlines()
+    title = None
+    body_start = 0
+    # Skip leading blanks; first non-blank line must be the title.
+    for i, line in enumerate(lines):
+        if not line.strip():
+            continue
+        m = TITLE_RE.match(line.strip())
+        if not m:
+            return None
+        title = m.group(1).strip()
+        body_start = i + 1
+        break
+    if title is None:
+        return None
+
+    out: Dict[str, Any] = {"title": title, "evidence": []}
+    in_evidence = False
+    for line in lines[body_start:]:
+        if in_evidence:
+            m = LIST_RE.match(line)
+            if m:
+                out["evidence"].append(m.group(1).strip())
+                continue
+            # First non-list-item line ends the evidence block.
+            in_evidence = False
+        if not line.strip():
+            continue
+        m = KV_RE.match(line)
+        if not m:
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if key == "evidence":
+            in_evidence = True
+            # Allow inline evidence: "evidence: foo" → single entry.
+            if val:
+                out["evidence"].append(val)
+            continue
+        out[key] = val
+
+    # Required fields per config/TOOLS.md: writer_agent + ≥1 evidence.
+    if not out.get("writer_agent"):
+        return None
+    if not out["evidence"]:
+        return None
+    # Default severity if absent.
+    out.setdefault("severity", "med")
+    return out
+
+
+# --- Data sources ---------------------------------------------------------
+
+
+def read_from_stdin_file() -> List[Dict[str, Any]]:
+    """Load fake drawers from a JSON file. Each entry is a dict mirroring
+    the MemPalace drawer shape: ``{drawer_id, room, content}``."""
+    with open(STDIN_FILE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError("stdin JSON must be a list of drawer dicts")
+    return data
+
+
+def read_from_mempalace() -> List[Dict[str, Any]]:
+    """Walk wing=WING via the in-process mempalace API. Read-only."""
+    try:
+        from mempalace.mcp_server import tool_list_drawers
+    except ImportError as e:
+        print(
+            f"Error: failed to import mempalace ({e}). "
+            "Install via pipx: pipx install 'mempalace>=3.3.3,<3.4'",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    drawers: List[Dict[str, Any]] = []
+    offset = 0
+    while len(drawers) < MAX_TOTAL_DRAWERS:
+        page = tool_list_drawers(wing=WING, limit=PAGE_SIZE, offset=offset)
+        batch = page.get("drawers", [])
+        if not batch:
+            break
+        drawers.extend(batch)
+        if len(batch) < PAGE_SIZE:
+            break  # last (partial) page reached
+        offset += PAGE_SIZE
+    return drawers
+
+
+# --- Clustering -----------------------------------------------------------
+
+
+def cluster_key_for(friction: Dict[str, Any], room: str) -> str:
+    """Cluster by subcategory if present, fallback to room (one of the
+    5 fixed categories per config/TOOLS.md)."""
+    sub = friction.get("subcategory", "").strip()
+    if sub:
+        return sub
+    return room or "unknown"
+
+
+def cluster_frictions(
+    parsed: List[Tuple[Dict[str, Any], str]],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Group parsed frictions by cluster key. Each value entry stores the
+    friction with its room glued in for downstream traceability."""
+    clusters: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for friction, room in parsed:
+        key = cluster_key_for(friction, room)
+        enriched = dict(friction)
+        enriched["_room"] = room
+        clusters[key].append(enriched)
+    return dict(clusters)
+
+
+def cluster_qualifies(cluster: List[Dict[str, Any]], threshold: int) -> bool:
+    """A cluster qualifies for an MR if it crosses the size threshold OR
+    contains at least one severity:high friction. The high-severity
+    bypass is per config/TOOLS.md to avoid ignoring blockers."""
+    if len(cluster) >= threshold:
+        return True
+    return any(f.get("severity") == "high" for f in cluster)
+
+
+# --- Routing --------------------------------------------------------------
+
+
+def pick_target_repo(cluster: List[Dict[str, Any]]) -> Optional[str]:
+    """Pick the MR target URL for a cluster.
+
+    Precedence:
+    1. ``--target-repo`` override (set by the wrapper for test or
+       single-fork curation).
+    2. The ``canonical`` URL most frequent across the cluster.
+    3. None — caller treats this as a routing failure (does not open a
+       blind MR).
+    """
+    if TARGET_OVERRIDE:
+        return TARGET_OVERRIDE
+    canonicals: Dict[str, int] = defaultdict(int)
+    for f in cluster:
+        c = f.get("canonical", "").strip()
+        if c:
+            canonicals[c] += 1
+    if not canonicals:
+        return None
+    # Most-frequent canonical wins, ties broken by first seen.
+    return max(canonicals.items(), key=lambda kv: kv[1])[0]
+
+
+# --- MR body composition --------------------------------------------------
+
+
+def compose_body(
+    cluster_key: str,
+    cluster: List[Dict[str, Any]],
+    target_repo: str,
+) -> Tuple[str, str]:
+    """Return (title, markdown_body)."""
+    size = len(cluster)
+    title = f"Friction cluster: {cluster_key} ({size} report{'s' if size != 1 else ''})"
+    lines: List[str] = []
+    lines.append(f"## Friction cluster: `{cluster_key}`")
+    lines.append("")
+    lines.append(
+        f"{size} friction{'s' if size != 1 else ''} tagged across the "
+        f"`harness-friction` wing. Routed to `{target_repo}`."
+    )
+    lines.append("")
+    # Pattern paragraph: leave room for human / future LLM enrichment in V0
+    # we just summarise the rooms involved.
+    rooms_seen = sorted({f.get("_room", "?") for f in cluster})
+    lines.append("### Pattern")
+    lines.append("")
+    lines.append(
+        f"Reports span room{'s' if len(rooms_seen) != 1 else ''} "
+        + ", ".join(f"`{r}`" for r in rooms_seen)
+        + ". The common subcategory anchor is "
+        f"`{cluster_key}`."
+    )
+    lines.append("")
+    lines.append("### Frictions")
+    lines.append("")
+    for i, f in enumerate(cluster, 1):
+        lines.append(f"{i}. **{f.get('title', '(untitled)')}**")
+        lines.append(f"   - Reported by: `{f.get('writer_agent', '?')}`")
+        lines.append(f"   - Severity: `{f.get('severity', 'med')}`")
+        room = f.get("_room", "?")
+        lines.append(f"   - Room: `{room}`")
+        for ev in f.get("evidence", []):
+            lines.append(f"   - Evidence: {ev}")
+        if f.get("suggestion"):
+            lines.append(f"   - Suggestion (from reporter): {f['suggestion']}")
+        lines.append("")
+    lines.append("### Suggested resolution")
+    lines.append("")
+    suggestions = [f["suggestion"] for f in cluster if f.get("suggestion")]
+    if suggestions:
+        if len(set(suggestions)) == 1:
+            lines.append(f"All reporters converge on: {suggestions[0]}")
+        else:
+            lines.append("Reporter suggestions diverge:")
+            for s in suggestions:
+                lines.append(f"- {s}")
+    else:
+        lines.append(
+            "No suggestion in payloads. Curator declined to invent one in "
+            "V0 (descriptive-only contract — see "
+            "`community-config/skills/harness-curator/SKILL.md`)."
+        )
+    lines.append("")
+    lines.append("### Out of scope")
+    lines.append("")
+    lines.append(
+        "This MR is descriptive only. The diff that actually fixes the "
+        "underlying issue is left to a human (or to a future auto-fix "
+        "mode of the Curator, deferred — see issue #42)."
+    )
+    lines.append("")
+    return title, "\n".join(lines)
+
+
+# --- Main -----------------------------------------------------------------
+
+
+def safe_slug(s: str) -> str:
+    """Slugify a cluster key for use in a branch name."""
+    s = re.sub(r"[^a-zA-Z0-9._-]+", "-", s).strip("-")
+    return s.lower() or "unknown"
+
+
+def main() -> int:
+    if STDIN_FILE:
+        try:
+            drawers = read_from_stdin_file()
+        except (OSError, ValueError) as e:
+            print(f"Error: failed to read stdin JSON: {e}", file=sys.stderr)
+            return 2
+    else:
+        drawers = read_from_mempalace()
+
+    stats = {
+        "total_drawers": len(drawers),
+        "valid_frictions": 0,
+        "skipped_malformed": 0,
+        "clusters_formed": 0,
+        "clusters_above_threshold": 0,
+        "clusters_parked": 0,
+        "routing_failures": 0,
+    }
+
+    parsed: List[Tuple[Dict[str, Any], str]] = []
+    for drawer in drawers:
+        content = drawer.get("content", "")
+        room = drawer.get("room", "")
+        friction = parse_friction(content)
+        if friction is None:
+            stats["skipped_malformed"] += 1
+            continue
+        parsed.append((friction, room))
+        stats["valid_frictions"] += 1
+
+    clusters = cluster_frictions(parsed)
+    stats["clusters_formed"] = len(clusters)
+
+    output_clusters: List[Dict[str, Any]] = []
+    for cluster_key, items in clusters.items():
+        if not cluster_qualifies(items, THRESHOLD):
+            stats["clusters_parked"] += 1
+            continue
+        target = pick_target_repo(items)
+        if target is None:
+            stats["routing_failures"] += 1
+            continue
+        stats["clusters_above_threshold"] += 1
+        title, body = compose_body(cluster_key, items, target)
+        branch = f"harness/{safe_slug(cluster_key)}-{TODAY}"
+        output_clusters.append({
+            "cluster_key": cluster_key,
+            "cluster_size": len(items),
+            "target_repo": target,
+            "title": title,
+            "body": body,
+            "branch_name": branch,
+            "frictions": items,
+        })
+
+    json.dump(
+        {"stats": stats, "clusters": output_clusters},
+        sys.stdout,
+        indent=2,
+        ensure_ascii=False,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/prune-transcripts.sh
+++ b/scripts/prune-transcripts.sh
@@ -82,6 +82,9 @@ fi
 
 # --- Dependencies: auto-detect pipx venv or fall back to python3 ---
 auto_detect_mempalace_python() {
+  # Always returns 0 — caller does not branch on exit code, and a non-zero
+  # return would trigger `set -e` on the calling assignment when no pipx
+  # mempalace venv exists (e.g. on a fresh CI runner).
   if command -v pipx >/dev/null 2>&1; then
     local pipx_venv
     pipx_venv=$(pipx environment --value PIPX_HOME 2>/dev/null)/venvs/mempalace
@@ -91,7 +94,6 @@ auto_detect_mempalace_python() {
     fi
   fi
   echo "python3"
-  return 1
 }
 
 MEMPALACE_PYTHON="${MEMPALACE_PYTHON:-$(auto_detect_mempalace_python)}"

--- a/tests/harness/sample-frictions.json
+++ b/tests/harness/sample-frictions.json
@@ -2,16 +2,19 @@
   {
     "drawer_id": "drw-001",
     "room": "prompt",
+    "filed_at": "2026-05-08T09:14:22.000000",
     "content": "FRICTION: Skill prompt suggests yq merge syntax that does not exist on yq v4\n\nwriter_agent: claude-code\nsubcategory: yq-merge\ncanonical: https://github.com/hcross/crewrig\nseverity: med\nevidence:\n  - community-config/skills/architect/SKILL.md:42\nsuggestion: Replace `yq m -i` with `yq eval-all '. as $i ireduce ...'`."
   },
   {
     "drawer_id": "drw-002",
     "room": "prompt",
-    "content": "FRICTION: yq merge example produced an empty file\n\nwriter_agent: gemini-cli\nsubcategory: yq-merge\ncanonical: https://github.com/hcross/crewrig\nseverity: med\nevidence:\n  - https://example.com/ci-run/12345\n  - community-config/skills/developer/SKILL.md:88\nsuggestion: Same fix — eval-all reduce form."
+    "filed_at": "2026-05-10T11:42:05.000000",
+    "content": "FRICTION: yq merge example produced an empty file\n\nwriter_agent: gemini-cli\nsubcategory: yq-merge\ncanonical: https://github.com/hcross/crewrig\nseverity: med\nevidence: https://example.com/ci-run/12345\nsuggestion: Same fix — eval-all reduce form."
   },
   {
     "drawer_id": "drw-003",
     "room": "tool",
+    "filed_at": "2026-05-09T17:03:11.000000",
     "content": "FRICTION: gh CLI silently truncates very long PR bodies\n\nwriter_agent: claude-code\nsubcategory: gh-body-truncation\ncanonical: https://github.com/hcross/crewrig\nseverity: high\nevidence:\n  - https://github.com/hcross/crewrig/pull/40#issuecomment-XXX\nsuggestion: Detect length > 65535 and chunk into a follow-up comment."
   },
   {
@@ -23,5 +26,11 @@
     "drawer_id": "drw-005",
     "room": "process",
     "content": "Not a friction at all — random text the curator should skip."
+  },
+  {
+    "drawer_id": "drw-006",
+    "room": "prompt",
+    "filed_at": "2026-05-10T08:00:00.000000",
+    "content": "FRICTION: Empty writer_agent — must be rejected per schema\n\nwriter_agent:\nsubcategory: should-be-rejected\ncanonical: https://github.com/hcross/crewrig\nseverity: med\nevidence:\n  - foo.md:1"
   }
 ]

--- a/tests/harness/sample-frictions.json
+++ b/tests/harness/sample-frictions.json
@@ -1,0 +1,27 @@
+[
+  {
+    "drawer_id": "drw-001",
+    "room": "prompt",
+    "content": "FRICTION: Skill prompt suggests yq merge syntax that does not exist on yq v4\n\nwriter_agent: claude-code\nsubcategory: yq-merge\ncanonical: https://github.com/hcross/crewrig\nseverity: med\nevidence:\n  - community-config/skills/architect/SKILL.md:42\nsuggestion: Replace `yq m -i` with `yq eval-all '. as $i ireduce ...'`."
+  },
+  {
+    "drawer_id": "drw-002",
+    "room": "prompt",
+    "content": "FRICTION: yq merge example produced an empty file\n\nwriter_agent: gemini-cli\nsubcategory: yq-merge\ncanonical: https://github.com/hcross/crewrig\nseverity: med\nevidence:\n  - https://example.com/ci-run/12345\n  - community-config/skills/developer/SKILL.md:88\nsuggestion: Same fix — eval-all reduce form."
+  },
+  {
+    "drawer_id": "drw-003",
+    "room": "tool",
+    "content": "FRICTION: gh CLI silently truncates very long PR bodies\n\nwriter_agent: claude-code\nsubcategory: gh-body-truncation\ncanonical: https://github.com/hcross/crewrig\nseverity: high\nevidence:\n  - https://github.com/hcross/crewrig/pull/40#issuecomment-XXX\nsuggestion: Detect length > 65535 and chunk into a follow-up comment."
+  },
+  {
+    "drawer_id": "drw-004",
+    "room": "behavior",
+    "content": "FRICTION: Solo low-severity friction with no cluster mate\n\nwriter_agent: claude-code\nsubcategory: parked-singleton\ncanonical: https://github.com/hcross/crewrig\nseverity: low\nevidence:\n  - some-file.md:1\nsuggestion: Will accumulate in subsequent runs."
+  },
+  {
+    "drawer_id": "drw-005",
+    "room": "process",
+    "content": "Not a friction at all — random text the curator should skip."
+  }
+]

--- a/tests/harness/test-curate.sh
+++ b/tests/harness/test-curate.sh
@@ -31,16 +31,12 @@ command -v python3 >/dev/null 2>&1 || {
 }
 
 echo "Running curator on fixture..."
-# Capture stdout to OUT and stderr to ERR so we can surface both.
+# Disable set -e momentarily so we can inspect a non-zero exit before
+# bailing — yields a clearer failure than a bare `set -e` abort.
 set +e
-ERR_FILE=$(mktemp)
-OUT=$(bash -x "$SCRIPT" --from-stdin --dry-run < "$FIXTURE" 2>"$ERR_FILE")
+OUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$FIXTURE")
 RC=$?
 set -e
-echo "--- inner stderr (bash -x trace + any errors) ---" >&2
-cat "$ERR_FILE" >&2
-echo "--- end inner stderr ---" >&2
-rm -f "$ERR_FILE"
 if [ "$RC" -ne 0 ] || [ -z "$OUT" ]; then
   echo "FAIL: harness-curate.sh exit=$RC, stdout-len=${#OUT}" >&2
   echo "--- captured stdout ---" >&2

--- a/tests/harness/test-curate.sh
+++ b/tests/harness/test-curate.sh
@@ -31,7 +31,18 @@ command -v python3 >/dev/null 2>&1 || {
 }
 
 echo "Running curator on fixture..."
+# Capture stdout to OUT, but let stderr pass through so failures surface in CI.
+# Disable set -e momentarily so we can inspect a non-zero exit before bailing.
+set +e
 OUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$FIXTURE")
+RC=$?
+set -e
+if [ "$RC" -ne 0 ] || [ -z "$OUT" ]; then
+  echo "FAIL: harness-curate.sh exit=$RC, stdout-len=${#OUT}" >&2
+  echo "--- captured stdout ---" >&2
+  printf '%s\n' "$OUT" >&2
+  exit 1
+fi
 
 # --- Assertions -----------------------------------------------------------
 

--- a/tests/harness/test-curate.sh
+++ b/tests/harness/test-curate.sh
@@ -31,12 +31,16 @@ command -v python3 >/dev/null 2>&1 || {
 }
 
 echo "Running curator on fixture..."
-# Capture stdout to OUT, but let stderr pass through so failures surface in CI.
-# Disable set -e momentarily so we can inspect a non-zero exit before bailing.
+# Capture stdout to OUT and stderr to ERR so we can surface both.
 set +e
-OUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$FIXTURE")
+ERR_FILE=$(mktemp)
+OUT=$(bash -x "$SCRIPT" --from-stdin --dry-run < "$FIXTURE" 2>"$ERR_FILE")
 RC=$?
 set -e
+echo "--- inner stderr (bash -x trace + any errors) ---" >&2
+cat "$ERR_FILE" >&2
+echo "--- end inner stderr ---" >&2
+rm -f "$ERR_FILE"
 if [ "$RC" -ne 0 ] || [ -z "$OUT" ]; then
   echo "FAIL: harness-curate.sh exit=$RC, stdout-len=${#OUT}" >&2
   echo "--- captured stdout ---" >&2

--- a/tests/harness/test-curate.sh
+++ b/tests/harness/test-curate.sh
@@ -56,12 +56,12 @@ assert() {
   fi
 }
 
-# 5 input drawers
-assert "stats.total_drawers"       "5" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+# 6 input drawers
+assert "stats.total_drawers"       "6" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
 
-# 4 valid (drw-005 is malformed)
+# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty writer_agent)
 assert "stats.valid_frictions"     "4" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
-assert "stats.skipped_malformed"   "1" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
+assert "stats.skipped_malformed"   "2" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
 
 # 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton
 assert "stats.clusters_formed"     "3" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
@@ -87,13 +87,31 @@ assert "yq-merge.cluster_size"     "2" "$(echo "$YQ" | jq -r '.cluster_size')"
 assert "yq-merge.target_repo"      "https://github.com/hcross/crewrig" \
   "$(echo "$YQ" | jq -r '.target_repo')"
 
-# Body must contain at least one evidence pointer (non-empty body assertion).
+# Both yq-merge frictions came from room="prompt"; assert the room
+# propagates correctly through cluster_frictions().
+YQ_ROOMS=$(echo "$YQ" | jq -r '[.frictions[]._room] | unique | join(",")')
+assert "yq-merge.frictions[*]._room" "prompt" "$YQ_ROOMS"
+
+# Inline evidence (drw-002 used `evidence: <url>` form) must produce
+# a single-entry list — not a parse miss.
+DRW2_EVIDENCE=$(echo "$YQ" | jq -r '.frictions[] | select(.title | test("empty file")) | .evidence | length')
+assert "drw-002.evidence count (inline form)" "1" "$DRW2_EVIDENCE"
+
+# Body must contain at least one evidence pointer.
 YQ_BODY=$(echo "$YQ" | jq -r '.body')
 echo "$YQ_BODY" | grep -q "community-config/skills/architect/SKILL.md:42" || {
   echo "FAIL: yq-merge body missing evidence pointer from drw-001" >&2
   exit 1
 }
 echo "  PASS yq-merge.body contains evidence"
+
+# Body must include the date range computed from filed_at metadata.
+echo "$YQ_BODY" | grep -q "2026-05-08 → 2026-05-10" || {
+  echo "FAIL: yq-merge body missing date range" >&2
+  echo "$YQ_BODY" >&2
+  exit 1
+}
+echo "  PASS yq-merge.body contains date range"
 
 # Branch name follows the harness/<slug>-<date> shape.
 YQ_BRANCH=$(echo "$YQ" | jq -r '.branch_name')
@@ -103,9 +121,11 @@ YQ_BRANCH=$(echo "$YQ" | jq -r '.branch_name')
 }
 echo "  PASS yq-merge.branch_name format"
 
-# High-severity singleton bypass produced its own MR.
+# High-severity singleton bypass produced its own MR; room is "tool".
 HIGH=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "gh-body-truncation")')
 [ -n "$HIGH" ] || { echo "FAIL: severity:high singleton not promoted" >&2; exit 1; }
+HIGH_ROOM=$(echo "$HIGH" | jq -r '.frictions[0]._room')
+assert "gh-body-truncation.frictions[0]._room" "tool" "$HIGH_ROOM"
 echo "  PASS severity:high singleton promoted to cluster"
 
 # Parked singleton is NOT in the clusters output.

--- a/tests/harness/test-curate.sh
+++ b/tests/harness/test-curate.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# tests/harness/test-curate.sh — Smoke test for scripts/harness-curate.sh
+#
+# Feeds the fixture in `tests/harness/sample-frictions.json` through
+# `scripts/harness-curate.sh --from-stdin --dry-run` and asserts on the
+# JSON output. Does not touch MemPalace or `gh` — pure offline test.
+#
+# Exit 0 on pass, non-zero with explanation on fail.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+FIXTURE="$REPO_DIR/tests/harness/sample-frictions.json"
+SCRIPT="$REPO_DIR/scripts/harness-curate.sh"
+
+[ -f "$FIXTURE" ] || { echo "FAIL: fixture missing: $FIXTURE" >&2; exit 1; }
+[ -x "$SCRIPT" ] || chmod +x "$SCRIPT"
+
+# `jq` is the assertion helper — it is the project's standard JSON tool
+# (already required by build-components.sh per its prerequisites).
+command -v jq >/dev/null 2>&1 || {
+  echo "FAIL: jq is required for test assertions" >&2
+  exit 1
+}
+
+# `python3` covers the --from-stdin path even without the mempalace pipx
+# venv. The script auto-falls back to it.
+command -v python3 >/dev/null 2>&1 || {
+  echo "FAIL: python3 is required" >&2
+  exit 1
+}
+
+echo "Running curator on fixture..."
+OUT=$(bash "$SCRIPT" --from-stdin --dry-run < "$FIXTURE")
+
+# --- Assertions -----------------------------------------------------------
+
+assert() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS $label"
+  else
+    echo "  FAIL $label — expected '$expected', got '$actual'" >&2
+    return 1
+  fi
+}
+
+# 5 input drawers
+assert "stats.total_drawers"       "5" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+
+# 4 valid (drw-005 is malformed)
+assert "stats.valid_frictions"     "4" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
+assert "stats.skipped_malformed"   "1" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
+
+# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton
+assert "stats.clusters_formed"     "3" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
+
+# Above threshold:
+#  - yq-merge (size 2, ≥ threshold)
+#  - gh-body-truncation (size 1 BUT severity:high → bypass)
+# Parked: parked-singleton (size 1, severity low)
+assert "stats.clusters_above_threshold" "2" \
+  "$(echo "$OUT" | jq -r '.stats.clusters_above_threshold')"
+assert "stats.clusters_parked"     "1" "$(echo "$OUT" | jq -r '.stats.clusters_parked')"
+
+# No routing failures (every cluster has canonical: set in the fixture)
+assert "stats.routing_failures"    "0" "$(echo "$OUT" | jq -r '.stats.routing_failures')"
+
+# Exactly 2 clusters in output
+assert "len(.clusters)"            "2" "$(echo "$OUT" | jq -r '.clusters | length')"
+
+# yq-merge cluster — 2 frictions, target hcross/crewrig
+YQ=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "yq-merge")')
+[ -n "$YQ" ] || { echo "FAIL: yq-merge cluster missing" >&2; exit 1; }
+assert "yq-merge.cluster_size"     "2" "$(echo "$YQ" | jq -r '.cluster_size')"
+assert "yq-merge.target_repo"      "https://github.com/hcross/crewrig" \
+  "$(echo "$YQ" | jq -r '.target_repo')"
+
+# Body must contain at least one evidence pointer (non-empty body assertion).
+YQ_BODY=$(echo "$YQ" | jq -r '.body')
+echo "$YQ_BODY" | grep -q "community-config/skills/architect/SKILL.md:42" || {
+  echo "FAIL: yq-merge body missing evidence pointer from drw-001" >&2
+  exit 1
+}
+echo "  PASS yq-merge.body contains evidence"
+
+# Branch name follows the harness/<slug>-<date> shape.
+YQ_BRANCH=$(echo "$YQ" | jq -r '.branch_name')
+[[ "$YQ_BRANCH" =~ ^harness/yq-merge-[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || {
+  echo "FAIL: yq-merge.branch_name unexpected: '$YQ_BRANCH'" >&2
+  exit 1
+}
+echo "  PASS yq-merge.branch_name format"
+
+# High-severity singleton bypass produced its own MR.
+HIGH=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "gh-body-truncation")')
+[ -n "$HIGH" ] || { echo "FAIL: severity:high singleton not promoted" >&2; exit 1; }
+echo "  PASS severity:high singleton promoted to cluster"
+
+# Parked singleton is NOT in the clusters output.
+PARKED=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "parked-singleton")')
+[ -z "$PARKED" ] || { echo "FAIL: parked-singleton should be parked, not in clusters" >&2; exit 1; }
+echo "  PASS parked-singleton excluded from output"
+
+echo ""
+echo "OK: harness-curate smoke test passed."


### PR DESCRIPTION
Closes the harness loop opened in PR A and PR B. Logbook: #41. Last of the three planned PRs — once merged, `release/crew-v0` is ready to flow to `main`.

## How to read this PR?

The new code is concentrated in three places. Read in this order:

1. `config/TOOLS.md` — new **Carve-out for bundled skill/agent scripts** clause. The whole PR depends on this: it's what allows the Curator to walk MemPalace via the Python library rather than per-call MCP. Read the clause in full so the constraints (read-mostly, library-not-CLI, source-controlled) are clear.
2. `scripts/lib/harness_curate.py` — the actual logic: payload parser, clusterer, MR body composer. Pure functions, deterministic, exhaustively unit-tested via the smoke test below.
3. `scripts/harness-curate.sh` — thin bash wrapper. Auto-detects the pipx mempalace venv, sets env vars, exec's the Python module. `--dry-run` (default) emits JSON; `--apply` opens MRs via `gh`.
4. `tests/harness/{sample-frictions.json,test-curate.sh}` — smoke test. 14 assertions cover the cluster shape, severity bypass, parked singleton, routing, branch naming, body content. Runs in CI on every PR.
5. `community-config/skills/harness-curator/SKILL.md` — skill body rewritten to walk the agent through *running the script* rather than reimplementing the workflow in-prompt. The agent's job shrinks to: run the script → read the stats → decide whether to `--apply` or open MRs manually for body enrichment.

Non-obvious decisions:

- **Carve-out, not a workaround.** The Curator could have stayed pure-MCP, but batch-reading the friction wing one drawer at a time would be a multi-thousand-call traversal. The carve-out is documented as a *contract*, not a license to bypass MCP — read-mostly, library-not-CLI, source-controlled, and the agent of record stays the agent.
- **Severity-`high` bypass is hard-coded, not a flag.** A single critical friction must always promote to a cluster. Making this a flag would invite footguns ("oops, I forgot `--include-high`").
- **Routing failures are surfaced, never blind.** A cluster with no resolvable `canonical:` and no `--target-repo` override stops at the stats — better a missed MR than a wrong-target MR.
- **End-to-end `--apply` is *not* in CI.** Opening real MRs against this repo from a CI runner is the kind of side effect that bites once and never lets you forget. The smoke test covers `--dry-run` exhaustively; `--apply` is verified manually post-merge by the maintainer.

## How to test this PR?

Prerequisites: `bash`, `python3`, `jq`. (No mempalace required for the smoke test — `--from-stdin` mode skips that import.)

```bash
# 1. Smoke test (this is what CI runs).
task test-harness-curate
# Expect: 14 PASS lines, "OK: harness-curate smoke test passed."

# 2. Inspect the dry-run output against the fixture.
bash scripts/harness-curate.sh --from-stdin --dry-run \
  < tests/harness/sample-frictions.json | jq '.stats, .clusters[].title'
# Expect:
#   total_drawers: 5, valid: 4, malformed: 1
#   2 clusters above threshold (yq-merge x2, gh-body-truncation severity:high singleton)
#   1 parked (parked-singleton low-severity)

# 3. End-to-end against MemPalace (requires live wing — typically empty
#    in a fresh checkout; will simply emit zero clusters).
task harness-curate -- --dry-run

# 4. Round-trip drift on regenerated component outputs.
bash scripts/build-components.sh --check
# Expect: "OK: All generated files match source."

# 5. Manual --apply verification (post-merge to main only).
#    task harness-curate -- --apply
#    Expect: 0 or N MRs opened against hcross/crewrig with label
#    `harness-feedback`. Skip if wing is empty.
```

## Detailed description (for agents)

### Added: `config/TOOLS.md` carve-out

New clause "Carve-out for bundled skill/agent scripts" added immediately after the existing MCP-only access paragraph. Defines the four conditions under which a bundled script may walk MemPalace directly:

1. Source-controlled alongside the skill that invokes it.
2. Uses the MemPalace Python library, not the shell CLI.
3. Read-mostly; any write path must justify why MCP cannot be used (in a comment at the call site).
4. The agent remains the agent of record; the Memory Activation Protocol still applies at session start.

The Curator is named as the canonical user, with the rationale (per-call MCP traversal infeasibility) made explicit.

### Added: `scripts/lib/harness_curate.py`

Pure-Python module. Reads from MemPalace (via `from mempalace.mcp_server import tool_list_drawers`) or from a stdin JSON file. Parses the `FRICTION:` payload schema documented in `config/TOOLS.md`. Clusters by `subcategory:` (fallback `room:`). Promotes clusters to MRs when size ≥ threshold OR any friction has `severity: high`. Routes to most-frequent `canonical:`; surfaces routing failures rather than opening blind. Composes a structured Markdown body per cluster. Emits a single JSON document on stdout with stable schema (`stats` + `clusters`).

### Added: `scripts/harness-curate.sh`

Thin bash wrapper. Auto-detects the pipx mempalace venv, falls back to system python3 in `--from-stdin` mode (which doesn't need mempalace). `--dry-run` prints the JSON; `--apply` parses it and opens one MR per cluster via `gh pr create` with branch `harness/<slug>-<date>` and label `harness-feedback`.

### Added: `tests/harness/sample-frictions.json` + `tests/harness/test-curate.sh`

Smoke test fixture covers four interesting cases in 5 drawers:

- Two `subcategory: yq-merge` frictions → cluster of size 2, qualifies (threshold).
- One `subcategory: gh-body-truncation` friction with `severity: high` → singleton, qualifies (severity bypass).
- One `subcategory: parked-singleton` low-severity → singleton, does NOT qualify, must appear in `clusters_parked`.
- One malformed drawer (no `FRICTION:` prefix) → must appear in `skipped_malformed`.

Test assertions: 14 of them, covering exact stats, cluster sizes, target repo routing, body containing evidence pointers, branch name format, and exclusion of parked singleton.

### Added: `.github/workflows/build.yml` job `test-harness-curate`

New CI job. Installs `jq` only (no mempalace, no python deps) and runs `bash tests/harness/test-curate.sh`. Runs on every PR alongside the existing build / check-components / lint-markdown jobs.

### Added: `Taskfile.yml` entries

- `task harness-curate -- [--apply | --from-stdin]` — full curator run.
- `task test-harness-curate` — smoke test (mirrors what CI runs).

### Modified: `community-config/skills/harness-curator/SKILL.md`

Operating-mode lifecycle rewritten. Previously the skill described the workflow steps (read → cluster → compose → open) as if the agent were performing them in-prompt; now it walks the agent through *running the script* and acting on the JSON. Threshold and routing rules remain documented (with override flags), so the skill stays readable as an agent contract even though the implementation lives in code.

### Out of scope (deferred — separate tickets)

- **Auto mode** (cron / reactive triggers): tracked in #42.
- **`--deep` mode** (sweep `wing="transcripts"` for unflagged friction patterns): tracked in #43.
- **End-to-end `--apply` in CI**: deliberate. CI opening real MRs against this repo is a footgun. Manual post-merge verification covers this path.