### PR TITLE
🐛 Generate Gemini agents as flat .md with required frontmatter

### DIFF
--- a/.gemini/agents/architect.md
+++ b/.gemini/agents/architect.md
@@ -1,3 +1,12 @@
+---
+name: architect
+description: "Generic architecture agent. Drafts ADRs, runs design reviews, proposes alternatives with explicit trade-offs, and maps blast radius."
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
+---
+
 
 # Architect Agent
 

--- a/.gemini/agents/developer.md
+++ b/.gemini/agents/developer.md
@@ -1,3 +1,12 @@
+---
+name: developer
+description: "Generic implementation agent. Writes, edits, and refactors code with the smallest correct change. Verifies locally before reporting done."
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
+---
+
 
 # Developer Agent
 

--- a/.gemini/agents/doc-writer.md
+++ b/.gemini/agents/doc-writer.md
@@ -1,3 +1,12 @@
+---
+name: doc-writer
+description: "Generic documentation agent. Drafts ADRs, READMEs, in-code docstrings, and reference material. Optimises for documents that age well and stays close to the code where possible."
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
+---
+
 
 # Doc Writer Agent
 

--- a/.gemini/agents/harness-curator.md
+++ b/.gemini/agents/harness-curator.md
@@ -1,3 +1,12 @@
+---
+name: harness-curator
+description: "Generic harness-curator agent. On-demand reader of the global harness-friction wing. Clusters frictions, drafts descriptive feedback MRs against the canonical/feedback repos. No auto-fix in V0."
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
+---
+
 
 # Harness Curator Agent
 

--- a/.gemini/agents/pr-logbook.md
+++ b/.gemini/agents/pr-logbook.md
@@ -1,3 +1,12 @@
+---
+name: pr-logbook
+description: "Generic PR and logbook composer agent. Drafts titles, bodies, test plans, logbook entries, and squash-merge commit messages that conform to the project's AGENTS.md conventions."
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
+---
+
 
 # PR & Logbook Agent
 

--- a/.gemini/agents/security.md
+++ b/.gemini/agents/security.md
@@ -1,3 +1,12 @@
+---
+name: security
+description: "Generic security review agent. Threat modeling, secret hygiene, realistic-threat code review, dependency audit. Findings only — does not implement fixes unless explicitly asked."
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
+---
+
 
 # Security Agent
 

--- a/.gemini/agents/tester.md
+++ b/.gemini/agents/tester.md
@@ -1,3 +1,12 @@
+---
+name: tester
+description: "Generic test-authoring agent. Writes high-signal regression tests, enumerates priority edge cases, and verifies fixes by failing-then-passing the test against the bug."
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
+---
+
 
 # Tester Agent
 

--- a/community-config/FORMAT.md
+++ b/community-config/FORMAT.md
@@ -21,7 +21,7 @@ and Claude Code.
 |------|----------------|-------------------|--------------------|
 | `skill` | `skills/<name>/SKILL.md` | `.gemini/skills/<name>/SKILL.md` | `.claude/skills/<name>/SKILL.md` |
 | `command` | `commands/<name>.md` | `.gemini/commands/<name>.toml` | `.claude/skills/<name>/SKILL.md` |
-| `agent` | `agents/<name>/AGENT.md` | `.gemini/agents/<name>/PROMPT.md` | `.claude/agents/<name>/AGENT.md` |
+| `agent` | `agents/<name>/AGENT.md` | `.gemini/agents/<name>.md` | `.claude/agents/<name>/AGENT.md` |
 
 Hooks, policies, and MCP servers use JSON formats and are handled
 separately by the build script (merged into tool-specific config files).
@@ -87,7 +87,9 @@ fields by default:
   the frontmatter, body as-is.
 - For `command`: generates a `.toml` file with `description` and the
   body wrapped in `prompt = """..."""`.
-- For `agent`: generates a `PROMPT.md` with the body only (no frontmatter).
+- For `agent`: generates a flat `.gemini/agents/<name>.md` file with YAML
+  frontmatter (`name`, `description`) — required by Gemini CLI's
+  sub-agent discovery — followed by the body as the system prompt.
 
 ### Claude Code Overrides (optional)
 
@@ -156,10 +158,18 @@ user-invocable: true
 
 ### Agent: `community-config/agents/<name>/AGENT.md`
 
-Gemini CLI → `.gemini/agents/<name>/PROMPT.md`
+Gemini CLI → `.gemini/agents/<name>.md`
 
-```markdown
-<body only, no frontmatter>
+```yaml
+---
+name: <name>
+description: <description>
+provenance:        # propagated when present in source
+  canonical: ...
+  feedback: ...
+  version: ...
+---
+<body — becomes the agent's system prompt>
 ```
 
 Claude Code → `.claude/agents/<name>/AGENT.md`

--- a/scripts/build-components.sh
+++ b/scripts/build-components.sh
@@ -382,11 +382,24 @@ build_agents() {
 
     echo "Building agent: $name"
 
-    # --- Gemini CLI output: PROMPT.md (body only) ---
-    # Gemini CLI discovers sub-agents at .gemini/agents/<name>/, NOT at the
-    # repo-root ./agents/ directory. The previous output path was unread.
+    # --- Gemini CLI output: <name>.md (flat file with YAML frontmatter) ---
+    # Per https://geminicli.com/docs/core/subagents/#creating-custom-subagents
+    # Gemini CLI requires a flat `.gemini/agents/<name>.md` file whose
+    # frontmatter declares `name` and `description` (required) and optional
+    # `tools`, `model`, etc. The body becomes the system prompt. A directory
+    # layout or a frontmatter-less body is not discovered.
     if [ "$TARGET" = "gemini" ] || [ "$TARGET" = "all" ]; then
-      check_or_write "$REPO_DIR/.gemini/agents/$name/PROMPT.md" "$body"
+      local gemini_content
+      gemini_content=$(cat <<GEMINI_EOF
+---
+name: $name
+description: "$description"
+---
+
+$body
+GEMINI_EOF
+      )
+      check_or_write "$REPO_DIR/.gemini/agents/$name.md" "$gemini_content" "$source"
     fi
 
     # --- Claude Code output: AGENT.md (with frontmatter) ---


### PR DESCRIPTION
Continuation of #49 — corrects the **filename and content shape** for Gemini sub-agents to match the upstream [Gemini CLI sub-agent spec](https://geminicli.com/docs/core/subagents/#creating-custom-subagents). #49 fixed the parent directory; this fixes everything downstream of that. Targets `release/crew-v0` so it folds into the open promotion PR (#48).

Tracked in #50; this PR closes the agent-output portion of that issue while leaving the extension-skeleton / install / DEVELOPMENT.md scope open for a follow-up.

## How to read this PR?

Two real edits + one rename batch:

1. `scripts/build-components.sh` — `build_agents` Gemini branch rewritten to emit a flat `.gemini/agents/<name>.md` file with YAML frontmatter (`name`, `description`) plus the body. Comment cites the spec.
2. `community-config/FORMAT.md` — three lines describing the agent build output now match the flat-file + frontmatter shape:
   - Type-mapping table (L24).
   - Description under *Gemini CLI Overrides* (L90).
   - *Build Outputs* example block (L159+).
3. The 7 stale `.gemini/agents/<name>/PROMPT.md` directories from #49 are removed; the regenerated outputs land as flat `.gemini/agents/<name>.md` files. Git tracks 7 renames at ~78–80 % similarity (frontmatter prepended, body unchanged).

## How to test this PR?

```bash
# 1. Round-trip clean.
task build-components
git diff --quiet || echo "(unexpected drift)"

# 2. Drift check passes.
task check-components
# Expect: "OK: All generated files match source."

# 3. The seven Gemini agent outputs are flat files with required frontmatter.
ls .gemini/agents/
# Expect: architect.md developer.md doc-writer.md harness-curator.md
#         pr-logbook.md security.md tester.md
head -5 .gemini/agents/architect.md
# Expect:
#   ---
#   name: architect
#   description: "..."
#   provenance:
#     ...

# 4. Smoke test still green (agent format change does not affect the curator).
task test-harness-curate
# Expect: 18 PASS lines.

# 5. (Manual, post-merge) Verify Gemini CLI loads at least one agent.
#    Open Gemini CLI in this repo and request the architect sub-agent.
```

## Detailed description (for agents)

### Build script change

`scripts/build-components.sh` — the Gemini branch of `build_agents` previously did:

```bash
check_or_write "$REPO_DIR/.gemini/agents/$name/PROMPT.md" "$body"
```

Now does:

```bash
gemini_content=$(cat <<GEMINI_EOF
---
name: $name
description: "$description"
---

$body
GEMINI_EOF
)
check_or_write "$REPO_DIR/.gemini/agents/$name.md" "$gemini_content" "$source"
```

The third arg (`$source`) routes the call through `inject_provenance`, which splices the source's `provenance:` block into the frontmatter immediately before the closing `---`. Gemini CLI's spec doesn't list `provenance:` but YAML parsers tolerate unknown fields, and the Curator needs it to route MRs.

### FORMAT.md updates

Three locations updated to describe the flat-file + frontmatter shape — the type-mapping table, the *Gemini CLI Overrides* paragraph, and the *Build Outputs* example block. The example now shows:

```yaml
---
name: <name>
description: <description>
provenance:        # propagated when present in source
  canonical: ...
  feedback: ...
  version: ...
---
<body — becomes the agent's system prompt>
```

### Out of scope (tracked in #50)

- `extension-skeleton/agent/agents/<name>/PROMPT.md` still authors the directory layout for extensions. Extensions installed via `manage-workspace-component.sh` would land in `~/.gemini/agents/<name>/PROMPT.md` and not be discovered by Gemini CLI.
- `scripts/manage-workspace-component.sh` propagates the bad layout on install.
- `DEVELOPMENT.md` still describes the old extension layout.

This PR addresses only the V0 crew agent build output (the immediate user-visible bug from #48). The extension authoring/install path stays on the existing layout until #50 is taken up. Forks that want correct Gemini agents today get them via this PR; forks that want correct Gemini-discoverable extensions wait on #50.

CI on this branch should be green: `build`, `check-components`, `grep-anti-patterns`, `lint-markdown`, `test-harness-curate`.