### PR TITLE
📝 Rename friction protocol: β-light → fire-and-forget tagging

### DIFF
--- a/config/TOOLS.md
+++ b/config/TOOLS.md
@@ -368,11 +368,12 @@ wrong thing, an output format that breaks downstream parsing — that
 signal must reach the maintainers of the agent system itself.
 Otherwise the same friction repeats forever.
 
-This section defines the **β-light tagging protocol**: agents tag
-frictions as they happen, never blocking the work in progress. A
-separate Curator agent (out of scope for this section) reads the tags
-on demand and proposes feedback MRs against the canonical/feedback
-repos declared in each component's `provenance:` block.
+This section defines the **fire-and-forget tagging protocol**: agents
+tag frictions as they happen, never blocking the work in progress and
+never waiting for a synchronous acknowledgement. A separate Curator
+agent (out of scope for this section) reads the tags on demand and
+proposes feedback MRs against the canonical/feedback repos declared
+in each component's `provenance:` block.
 
 ### When to tag
 


### PR DESCRIPTION
Renames the friction tagging protocol introduced in PR #46. Logbook: #41. Cosmetic fix on the V0 release branch; folds into PR #48 automatically.

## How to read this PR?

One-line change in one file. `config/TOOLS.md` (Friction Reporting section opener) renamed from `β-light tagging protocol` to `fire-and-forget tagging protocol`. Body of the introductory paragraph adjusted to mention the synchronous-acknowledgement aspect that the new name implies.

`β-light` was a placeholder term coined during the interactive #41 design discussion and had no external reference. A reader cold-opening TOOLS.md had to guess its meaning. `Fire-and-forget` is the standard distributed-systems idiom for exactly the behaviour we implement: the producer emits a tag and keeps working without waiting for a synchronous reply from the consumer.

## How to test this PR?

```bash
# 1. The new term is in place.
grep -c "fire-and-forget tagging" config/TOOLS.md
# Expect: 1
grep -c "β-light" config/TOOLS.md
# Expect: 0

# 2. Drift + smoke still green (TOOLS.md is not a build source).
task check-components
task test-harness-curate
```

## Detailed description (for agents)

- `config/TOOLS.md` line 371 — the Friction Reporting section opener now reads "This section defines the **fire-and-forget tagging protocol**: agents tag frictions as they happen, never blocking the work in progress **and never waiting for a synchronous acknowledgement**."
- No skill, agent, script, or test references the old term — verified by `grep -rni 'β-light\|beta.light\|β-tag' --include='*.md' --include='*.sh' --include='*.py'`.
- Historical issue bodies (#41, #42) still mention `β-light` + `α` framing. Those are records of the design discussion and are left as-is; the **current contract** lives in `config/TOOLS.md` and is now correctly named.