### PR TITLE
✨ Extract friction reporting into a dedicated `harness-report` skill

### DIFF
--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -29,5 +29,8 @@ If you find yourself producing a 2-page Context section for an ADR, the
 decision is not yet crisp. Stop, compress the context, then continue.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -28,5 +28,6 @@ the user.
 If you find yourself producing a 2-page Context section for an ADR, the
 decision is not yet crisp. Stop, compress the context, then continue.
 
-Tag frictions per `config/TOOLS.md` whenever the architect skill itself
-led you down a wrong path or missed a blast-radius dimension.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.claude/agents/developer/AGENT.md
+++ b/.claude/agents/developer/AGENT.md
@@ -32,5 +32,6 @@ verification you did not perform.
 When several subtasks are independent, dispatch them in parallel. When
 they share a file or a contract, serialise.
 
-Tag frictions per `config/TOOLS.md` whenever a tool, a prompt, or a
-process step wasted cycles.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.claude/agents/developer/AGENT.md
+++ b/.claude/agents/developer/AGENT.md
@@ -33,5 +33,8 @@ When several subtasks are independent, dispatch them in parallel. When
 they share a file or a contract, serialise.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.claude/agents/doc-writer/AGENT.md
+++ b/.claude/agents/doc-writer/AGENT.md
@@ -37,5 +37,6 @@ Before committing any document, you ask yourself which parts will be
 wrong in six months, and move those parts closer to the code if you
 can.
 
-Tag frictions per `config/TOOLS.md` when a doc template is contradictory
-or when you produced a doc the user had to substantially rewrite.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.claude/agents/doc-writer/AGENT.md
+++ b/.claude/agents/doc-writer/AGENT.md
@@ -38,5 +38,8 @@ wrong in six months, and move those parts closer to the code if you
 can.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.claude/agents/harness-curator/AGENT.md
+++ b/.claude/agents/harness-curator/AGENT.md
@@ -33,6 +33,7 @@ You always end a run with a summary: frictions read, frictions skipped
 as malformed, clusters formed, clusters that hit threshold, MRs opened
 with links, routing failures.
 
-You are not exempt from the loop you serve. If your own behaviour
-produced a bad cluster or an unactionable MR, tag the friction per
-`config/TOOLS.md`.
+You are not exempt from the loop you serve. When a recognition signal
+fires (see `config/TOOLS.md` → *Friction Reporting*), invoke the
+`harness-report` skill — it is the single canonical implementation of
+the tagging protocol.

--- a/.claude/agents/harness-curator/AGENT.md
+++ b/.claude/agents/harness-curator/AGENT.md
@@ -34,6 +34,6 @@ as malformed, clusters formed, clusters that hit threshold, MRs opened
 with links, routing failures.
 
 You are not exempt from the loop you serve. When a recognition signal
-fires (see `config/TOOLS.md` → *Friction Reporting*), invoke the
-`harness-report` skill — it is the single canonical implementation of
-the tagging protocol.
+fires (see `config/TOOLS.md` → *Friction Reporting → Recognition
+signals*), follow the procedure in the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`).

--- a/.claude/agents/pr-logbook/AGENT.md
+++ b/.claude/agents/pr-logbook/AGENT.md
@@ -33,6 +33,6 @@ When the project squash-merges, you treat the squash commit message as
 the document that survives in `git log` forever, and compose it
 deliberately rather than pasting the PR description.
 
-Tag frictions per `config/TOOLS.md` when a project's PR template is
-contradictory or when you produced a body the user had to substantially
-rewrite.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.claude/agents/pr-logbook/AGENT.md
+++ b/.claude/agents/pr-logbook/AGENT.md
@@ -34,5 +34,8 @@ the document that survives in `git log` forever, and compose it
 deliberately rather than pasting the PR description.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.claude/agents/security/AGENT.md
+++ b/.claude/agents/security/AGENT.md
@@ -33,5 +33,6 @@ You activate mandatorily on any change touching auth, secrets, crypto,
 external-input parsing, deserialisation, outbound network calls, or
 dependency upgrades on those surfaces.
 
-Tag frictions per `config/TOOLS.md` when a tool gives false positives
-or the skill prompt missed a class of threat.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.claude/agents/security/AGENT.md
+++ b/.claude/agents/security/AGENT.md
@@ -34,5 +34,8 @@ external-input parsing, deserialisation, outbound network calls, or
 dependency upgrades on those surfaces.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.claude/agents/tester/AGENT.md
+++ b/.claude/agents/tester/AGENT.md
@@ -33,5 +33,8 @@ for one, you say so and stop — do not invent a framework on the user's
 behalf.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.claude/agents/tester/AGENT.md
+++ b/.claude/agents/tester/AGENT.md
@@ -32,6 +32,6 @@ If the project has no test infrastructure and the user has not asked
 for one, you say so and stop — do not invent a framework on the user's
 behalf.
 
-Tag frictions per `config/TOOLS.md` when the test runner has a sharp
-edge, the project's test-writing convention is unclear, or a skill
-prompt led you to coverage-theatre tests.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -90,9 +90,8 @@ not been thought through yet.
 
 ## Friction reporting
 
-If the architecture skill itself led you down a wrong path (e.g. forced
-a heavyweight ADR on a trivial change, or missed a blast-radius
-dimension), tag it per `config/TOOLS.md` → *Friction Reporting*.
-
-Use `room="prompt"` (the prompt was misleading) or `room="process"`
-(the workflow itself has a gap).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.claude/skills/developer/SKILL.md
+++ b/.claude/skills/developer/SKILL.md
@@ -88,11 +88,8 @@ independent — serialise them.
 
 ## Friction reporting
 
-Tag frictions per `config/TOOLS.md` → *Friction Reporting* whenever:
-
-- A skill prompt led you to a wrong implementation path
-  (`room="prompt"`).
-- A tool produced surprising or inconsistent behaviour
-  (`room="tool"`).
-- A documented step in the project's workflow is missing or ambiguous
-  (`room="process"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.claude/skills/doc-writer/SKILL.md
+++ b/.claude/skills/doc-writer/SKILL.md
@@ -136,9 +136,8 @@ Standalone docs that drift silently are worse than no docs.
 
 ## Friction reporting
 
-Tag per `config/TOOLS.md` → *Friction Reporting* when:
-
-- A doc template (ADR, README scaffold) was contradictory or out of
-  date (`room="process"`).
-- The skill produced a doc the user had to substantially rewrite
-  (`room="prompt"` or `room="format"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.claude/skills/harness-curator/SKILL.md
+++ b/.claude/skills/harness-curator/SKILL.md
@@ -145,7 +145,9 @@ run is worth reporting — it tells the user the wing is healthy.
 
 ## Friction reporting
 
-The Curator can itself produce friction. If the curation prompt led to
-a bad cluster, a wrong target, or an unactionable MR, tag per
-`config/TOOLS.md` → *Friction Reporting* with `room="prompt"` or
-`room="behavior"`. The Curator is not exempt from the loop it serves.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The Curator is not exempt from the loop it serves — if the
+curation prompt led to a bad cluster, a wrong routing target, or an
+unactionable MR, report it like any other friction.

--- a/.claude/skills/harness-report/SKILL.md
+++ b/.claude/skills/harness-report/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: harness-report
+description: "Tag a friction encountered during real work. Activate the moment any recognition signal fires (user pushback, second-time tool surprise, sibling-skill workaround, etc.). The single canonical implementation of the friction-tagging protocol — all other skills point here."
+allowed-tools:
+  - Read
+user-invocable: true
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
+---
+
+
+# Harness Report
+
+The skill every other skill invokes when a friction signal fires. The
+protocol contract (payload schema, wing routing, fixed categories,
+what NOT to tag) lives in `config/TOOLS.md` → *Friction Reporting*.
+This skill is the *operational* counterpart: how to recognise a
+signal, how to fill the payload correctly, and especially how to
+attribute the friction to the right offender even when you are not
+currently operating under that offender's skill.
+
+## When to activate
+
+The moment any recognition signal fires. Listed in canonical form in
+`config/TOOLS.md` → *Friction Reporting → Recognition signals*; the
+short reminder list:
+
+- **User pushback** — the user contests, corrects, or reverts the
+  action you just took, or reformulates the same intent because your
+  previous response was misaligned.
+- **Sibling-skill workaround** — you find yourself contorting around
+  a constraint set by another skill or agent, not the user's request.
+- **Tool surprise (second time)** — a tool produced surprising or
+  inconsistent behaviour for the second time in the same session.
+  First time is bad luck; second time is a pattern.
+- **Process gap** — a documented workflow step turned out to be
+  missing, ambiguous, contradictory, or out of date.
+- **Safeguard friction** — a rule or guard blocked a legitimate action
+  and forced a workaround you had to justify.
+
+If a signal fires, **tag the friction before resuming work**. Not
+"consider tagging". Not "when convenient". Tagging takes seconds and
+costs nothing; failing to tag loses the signal forever.
+
+## Operating mode
+
+### 1. Pause and identify the offender
+
+The trickiest part of friction reporting is **getting the attribution
+right**. You are likely operating under some skill X when the friction
+manifests, but the *offender* might be:
+
+- Skill X itself (its prompt led you astray).
+- A *different* skill or agent you read earlier in the session.
+- A document (`AGENTS.md`, a `config/*.md` file).
+- A tool (`gh`, `jq`, `yq`, an MCP server).
+- A process step in `config/TOOLS.md` or similar.
+
+Before composing the payload, ask yourself: *what specifically led to
+the contested action?* Trace the chain backwards from the action to
+its closest source. That source is the offender, and its URL or path
+belongs in `canonical:` — **never the path to this `harness-report`
+skill**, which is just the orchestrator.
+
+If you genuinely cannot pinpoint the offender, leave `canonical:`
+empty and let `evidence:` carry the trail. A routing failure (caught
+by the Curator at consumption time) is better than a wrong-target MR.
+
+### 2. Pick the room
+
+One of the 5 fixed categories per `config/TOOLS.md`:
+
+- `tool` — an MCP tool, CLI, or script behaved unexpectedly.
+- `prompt` — a skill/agent prompt was misleading or led you astray.
+- `format` — an output format broke parsing or mixed concerns.
+- `behavior` — an agent did something it should not have, or skipped
+  something it should have done.
+- `process` — a documented workflow step is missing or out of date.
+
+When in doubt between `prompt` and `behavior`: ask whether the prompt
+*told* you to do the wrong thing (→ `prompt`) or whether you went off
+the prompt's rails on your own (→ `behavior`).
+
+### 3. Fill the payload
+
+Mandatory fields (the script will skip the drawer if either is
+missing or empty):
+
+- `writer_agent` — your own identifier (`claude-code`, `gemini-cli`,
+  …). Non-empty.
+- ≥1 `evidence:` entry — at minimum a file path with line number; a
+  commit hash + path + line is better (the file may move but the
+  commit is permanent).
+
+Strongly encouraged:
+
+- `subcategory` — a free-form clustering anchor. Frictions sharing a
+  `subcategory` get bundled into the same MR by the Curator.
+- `canonical` — the canonical URL of the offending component (from
+  its own `provenance.canonical` block when available).
+- `severity` — `low` / `med` / `high`. Default `med`. Reserve `high`
+  for blockers; it bypasses the cluster threshold and forces an MR.
+- `suggestion` — what you think would fix it. The Curator weighs
+  clusters with suggestions higher.
+
+The full schema, including the inline `evidence: <single-value>`
+short form, lives in `config/TOOLS.md` → *Payload schema*. Do not
+re-derive it here; refer to it.
+
+### 4. Tag
+
+One MCP call. Fire and forget — do not wait for an acknowledgement,
+do not block, return to your task:
+
+```text
+mempalace_add_drawer(
+  wing="harness-friction",
+  room="<one of the 5 categories>",
+  content="""
+FRICTION: <one-line title>
+
+writer_agent: <you>
+subcategory: <optional anchor>
+canonical: <URL of offender, if known>
+severity: <low|med|high — default med>
+evidence:
+  - <commit_hash>:<path>:<line>
+  - <URL>
+suggestion: <optional fix idea>
+"""
+)
+```
+
+### 5. Resume
+
+Return to the task that was interrupted by the signal. The friction
+is now in the wing; the Curator will pick it up on its next run.
+
+## Output expectations
+
+- A single `mempalace_add_drawer` MCP call to
+  `wing="harness-friction"`. Nothing else — no summary to the user,
+  no inline narration. The point of fire-and-forget is to keep the
+  flow.
+- If the user explicitly asked you to tag a friction, briefly confirm
+  it landed (one sentence). Otherwise stay silent.
+
+## Self-reporting bias
+
+A known weakness: the agent who produced the contested action is the
+one being asked to tag the friction. Rationalisation is easier than
+self-correction. To counteract this:
+
+- **When in doubt, tag.** Over-reporting is curatable; under-reporting
+  is lost forever. Curation cost is cheap relative to the cost of an
+  unflagged systemic friction.
+- **A user correction is always a recognition signal**, even when you
+  privately think "the user just changed their mind". The Curator
+  will downgrade if the cluster proves to be preference rather than
+  defect.
+
+## Friction reporting (recursive)
+
+If `harness-report` itself led to a malformed payload, a wrong
+attribution, or made you skip a tag that should have happened — tag
+it like any other friction, with `canonical` pointing at this skill's
+own URL. The reporter is not exempt from the loop it serves.

--- a/.claude/skills/harness-report/SKILL.md
+++ b/.claude/skills/harness-report/SKILL.md
@@ -38,7 +38,7 @@ short reminder list:
 - **Process gap** — a documented workflow step turned out to be
   missing, ambiguous, contradictory, or out of date.
 - **Safeguard friction** — a rule or guard blocked a legitimate action
-  and forced a workaround you had to justify.
+  and forced a workaround you had to explain explicitly to the user.
 
 If a signal fires, **tag the friction before resuming work**. Not
 "consider tagging". Not "when convenient". Tagging takes seconds and

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -117,9 +117,8 @@ Do not paste the entire PR description. The commit message is denser.
 
 ## Friction reporting
 
-Tag per `config/TOOLS.md` → *Friction Reporting* when:
-
-- The project's PR template is contradictory or out of date
-  (`room="process"`).
-- The skill produced a body that the user had to substantially rewrite
-  (`room="prompt"` or `room="format"` depending on the cause).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -112,11 +112,8 @@ When asked to review a dependency upgrade:
 
 ## Friction reporting
 
-Tag frictions per `config/TOOLS.md` → *Friction Reporting* when:
-
-- A security tool gave a false positive that wasted review cycles
-  (`room="tool"`).
-- The skill prompt missed a class of threat that surfaced anyway
-  (`room="prompt"`).
-- A project process step (e.g. dependency upgrade workflow) skipped a
-  required check (`room="process"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.claude/skills/tester/SKILL.md
+++ b/.claude/skills/tester/SKILL.md
@@ -109,11 +109,8 @@ A test that never failed before the fix proves nothing.
 
 ## Friction reporting
 
-Tag per `config/TOOLS.md` → *Friction Reporting* when:
-
-- A test framework / runner has a sharp edge that wasted time
-  (`room="tool"`).
-- The project's test-writing convention is unclear or contradictory
-  (`room="process"`).
-- A skill prompt led you to write coverage-theatre tests
-  (`room="prompt"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.gemini/agents/architect.md
+++ b/.gemini/agents/architect.md
@@ -29,5 +29,8 @@ If you find yourself producing a 2-page Context section for an ADR, the
 decision is not yet crisp. Stop, compress the context, then continue.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.gemini/agents/architect.md
+++ b/.gemini/agents/architect.md
@@ -28,5 +28,6 @@ the user.
 If you find yourself producing a 2-page Context section for an ADR, the
 decision is not yet crisp. Stop, compress the context, then continue.
 
-Tag frictions per `config/TOOLS.md` whenever the architect skill itself
-led you down a wrong path or missed a blast-radius dimension.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.gemini/agents/developer.md
+++ b/.gemini/agents/developer.md
@@ -32,5 +32,6 @@ verification you did not perform.
 When several subtasks are independent, dispatch them in parallel. When
 they share a file or a contract, serialise.
 
-Tag frictions per `config/TOOLS.md` whenever a tool, a prompt, or a
-process step wasted cycles.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.gemini/agents/developer.md
+++ b/.gemini/agents/developer.md
@@ -33,5 +33,8 @@ When several subtasks are independent, dispatch them in parallel. When
 they share a file or a contract, serialise.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.gemini/agents/doc-writer.md
+++ b/.gemini/agents/doc-writer.md
@@ -37,5 +37,6 @@ Before committing any document, you ask yourself which parts will be
 wrong in six months, and move those parts closer to the code if you
 can.
 
-Tag frictions per `config/TOOLS.md` when a doc template is contradictory
-or when you produced a doc the user had to substantially rewrite.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.gemini/agents/doc-writer.md
+++ b/.gemini/agents/doc-writer.md
@@ -38,5 +38,8 @@ wrong in six months, and move those parts closer to the code if you
 can.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.gemini/agents/harness-curator.md
+++ b/.gemini/agents/harness-curator.md
@@ -33,6 +33,7 @@ You always end a run with a summary: frictions read, frictions skipped
 as malformed, clusters formed, clusters that hit threshold, MRs opened
 with links, routing failures.
 
-You are not exempt from the loop you serve. If your own behaviour
-produced a bad cluster or an unactionable MR, tag the friction per
-`config/TOOLS.md`.
+You are not exempt from the loop you serve. When a recognition signal
+fires (see `config/TOOLS.md` → *Friction Reporting*), invoke the
+`harness-report` skill — it is the single canonical implementation of
+the tagging protocol.

--- a/.gemini/agents/harness-curator.md
+++ b/.gemini/agents/harness-curator.md
@@ -34,6 +34,6 @@ as malformed, clusters formed, clusters that hit threshold, MRs opened
 with links, routing failures.
 
 You are not exempt from the loop you serve. When a recognition signal
-fires (see `config/TOOLS.md` → *Friction Reporting*), invoke the
-`harness-report` skill — it is the single canonical implementation of
-the tagging protocol.
+fires (see `config/TOOLS.md` → *Friction Reporting → Recognition
+signals*), follow the procedure in the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`).

--- a/.gemini/agents/pr-logbook.md
+++ b/.gemini/agents/pr-logbook.md
@@ -33,6 +33,6 @@ When the project squash-merges, you treat the squash commit message as
 the document that survives in `git log` forever, and compose it
 deliberately rather than pasting the PR description.
 
-Tag frictions per `config/TOOLS.md` when a project's PR template is
-contradictory or when you produced a body the user had to substantially
-rewrite.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.gemini/agents/pr-logbook.md
+++ b/.gemini/agents/pr-logbook.md
@@ -34,5 +34,8 @@ the document that survives in `git log` forever, and compose it
 deliberately rather than pasting the PR description.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.gemini/agents/security.md
+++ b/.gemini/agents/security.md
@@ -33,5 +33,6 @@ You activate mandatorily on any change touching auth, secrets, crypto,
 external-input parsing, deserialisation, outbound network calls, or
 dependency upgrades on those surfaces.
 
-Tag frictions per `config/TOOLS.md` when a tool gives false positives
-or the skill prompt missed a class of threat.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.gemini/agents/security.md
+++ b/.gemini/agents/security.md
@@ -34,5 +34,8 @@ external-input parsing, deserialisation, outbound network calls, or
 dependency upgrades on those surfaces.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.gemini/agents/tester.md
+++ b/.gemini/agents/tester.md
@@ -33,5 +33,8 @@ for one, you say so and stop — do not invent a framework on the user's
 behalf.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/.gemini/agents/tester.md
+++ b/.gemini/agents/tester.md
@@ -32,6 +32,6 @@ If the project has no test infrastructure and the user has not asked
 for one, you say so and stop — do not invent a framework on the user's
 behalf.
 
-Tag frictions per `config/TOOLS.md` when the test runner has a sharp
-edge, the project's test-writing convention is unclear, or a skill
-prompt led you to coverage-theatre tests.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/.gemini/skills/architect/SKILL.md
+++ b/.gemini/skills/architect/SKILL.md
@@ -84,9 +84,8 @@ not been thought through yet.
 
 ## Friction reporting
 
-If the architecture skill itself led you down a wrong path (e.g. forced
-a heavyweight ADR on a trivial change, or missed a blast-radius
-dimension), tag it per `config/TOOLS.md` → *Friction Reporting*.
-
-Use `room="prompt"` (the prompt was misleading) or `room="process"`
-(the workflow itself has a gap).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.gemini/skills/developer/SKILL.md
+++ b/.gemini/skills/developer/SKILL.md
@@ -80,11 +80,8 @@ independent — serialise them.
 
 ## Friction reporting
 
-Tag frictions per `config/TOOLS.md` → *Friction Reporting* whenever:
-
-- A skill prompt led you to a wrong implementation path
-  (`room="prompt"`).
-- A tool produced surprising or inconsistent behaviour
-  (`room="tool"`).
-- A documented step in the project's workflow is missing or ambiguous
-  (`room="process"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.gemini/skills/doc-writer/SKILL.md
+++ b/.gemini/skills/doc-writer/SKILL.md
@@ -129,9 +129,8 @@ Standalone docs that drift silently are worse than no docs.
 
 ## Friction reporting
 
-Tag per `config/TOOLS.md` → *Friction Reporting* when:
-
-- A doc template (ADR, README scaffold) was contradictory or out of
-  date (`room="process"`).
-- The skill produced a doc the user had to substantially rewrite
-  (`room="prompt"` or `room="format"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.gemini/skills/harness-curator/SKILL.md
+++ b/.gemini/skills/harness-curator/SKILL.md
@@ -139,7 +139,9 @@ run is worth reporting — it tells the user the wing is healthy.
 
 ## Friction reporting
 
-The Curator can itself produce friction. If the curation prompt led to
-a bad cluster, a wrong target, or an unactionable MR, tag per
-`config/TOOLS.md` → *Friction Reporting* with `room="prompt"` or
-`room="behavior"`. The Curator is not exempt from the loop it serves.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The Curator is not exempt from the loop it serves — if the
+curation prompt led to a bad cluster, a wrong routing target, or an
+unactionable MR, report it like any other friction.

--- a/.gemini/skills/harness-report/SKILL.md
+++ b/.gemini/skills/harness-report/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: harness-report
+description: "Tag a friction encountered during real work. Activate the moment any recognition signal fires (user pushback, second-time tool surprise, sibling-skill workaround, etc.). The single canonical implementation of the friction-tagging protocol — all other skills point here."
+provenance:
+  canonical: "https://github.com/hcross/crewrig"
+  feedback: "https://github.com/hcross/crewrig"
+  version: "1.0.0"
+---
+
+
+# Harness Report
+
+The skill every other skill invokes when a friction signal fires. The
+protocol contract (payload schema, wing routing, fixed categories,
+what NOT to tag) lives in `config/TOOLS.md` → *Friction Reporting*.
+This skill is the *operational* counterpart: how to recognise a
+signal, how to fill the payload correctly, and especially how to
+attribute the friction to the right offender even when you are not
+currently operating under that offender's skill.
+
+## When to activate
+
+The moment any recognition signal fires. Listed in canonical form in
+`config/TOOLS.md` → *Friction Reporting → Recognition signals*; the
+short reminder list:
+
+- **User pushback** — the user contests, corrects, or reverts the
+  action you just took, or reformulates the same intent because your
+  previous response was misaligned.
+- **Sibling-skill workaround** — you find yourself contorting around
+  a constraint set by another skill or agent, not the user's request.
+- **Tool surprise (second time)** — a tool produced surprising or
+  inconsistent behaviour for the second time in the same session.
+  First time is bad luck; second time is a pattern.
+- **Process gap** — a documented workflow step turned out to be
+  missing, ambiguous, contradictory, or out of date.
+- **Safeguard friction** — a rule or guard blocked a legitimate action
+  and forced a workaround you had to justify.
+
+If a signal fires, **tag the friction before resuming work**. Not
+"consider tagging". Not "when convenient". Tagging takes seconds and
+costs nothing; failing to tag loses the signal forever.
+
+## Operating mode
+
+### 1. Pause and identify the offender
+
+The trickiest part of friction reporting is **getting the attribution
+right**. You are likely operating under some skill X when the friction
+manifests, but the *offender* might be:
+
+- Skill X itself (its prompt led you astray).
+- A *different* skill or agent you read earlier in the session.
+- A document (`AGENTS.md`, a `config/*.md` file).
+- A tool (`gh`, `jq`, `yq`, an MCP server).
+- A process step in `config/TOOLS.md` or similar.
+
+Before composing the payload, ask yourself: *what specifically led to
+the contested action?* Trace the chain backwards from the action to
+its closest source. That source is the offender, and its URL or path
+belongs in `canonical:` — **never the path to this `harness-report`
+skill**, which is just the orchestrator.
+
+If you genuinely cannot pinpoint the offender, leave `canonical:`
+empty and let `evidence:` carry the trail. A routing failure (caught
+by the Curator at consumption time) is better than a wrong-target MR.
+
+### 2. Pick the room
+
+One of the 5 fixed categories per `config/TOOLS.md`:
+
+- `tool` — an MCP tool, CLI, or script behaved unexpectedly.
+- `prompt` — a skill/agent prompt was misleading or led you astray.
+- `format` — an output format broke parsing or mixed concerns.
+- `behavior` — an agent did something it should not have, or skipped
+  something it should have done.
+- `process` — a documented workflow step is missing or out of date.
+
+When in doubt between `prompt` and `behavior`: ask whether the prompt
+*told* you to do the wrong thing (→ `prompt`) or whether you went off
+the prompt's rails on your own (→ `behavior`).
+
+### 3. Fill the payload
+
+Mandatory fields (the script will skip the drawer if either is
+missing or empty):
+
+- `writer_agent` — your own identifier (`claude-code`, `gemini-cli`,
+  …). Non-empty.
+- ≥1 `evidence:` entry — at minimum a file path with line number; a
+  commit hash + path + line is better (the file may move but the
+  commit is permanent).
+
+Strongly encouraged:
+
+- `subcategory` — a free-form clustering anchor. Frictions sharing a
+  `subcategory` get bundled into the same MR by the Curator.
+- `canonical` — the canonical URL of the offending component (from
+  its own `provenance.canonical` block when available).
+- `severity` — `low` / `med` / `high`. Default `med`. Reserve `high`
+  for blockers; it bypasses the cluster threshold and forces an MR.
+- `suggestion` — what you think would fix it. The Curator weighs
+  clusters with suggestions higher.
+
+The full schema, including the inline `evidence: <single-value>`
+short form, lives in `config/TOOLS.md` → *Payload schema*. Do not
+re-derive it here; refer to it.
+
+### 4. Tag
+
+One MCP call. Fire and forget — do not wait for an acknowledgement,
+do not block, return to your task:
+
+```text
+mempalace_add_drawer(
+  wing="harness-friction",
+  room="<one of the 5 categories>",
+  content="""
+FRICTION: <one-line title>
+
+writer_agent: <you>
+subcategory: <optional anchor>
+canonical: <URL of offender, if known>
+severity: <low|med|high — default med>
+evidence:
+  - <commit_hash>:<path>:<line>
+  - <URL>
+suggestion: <optional fix idea>
+"""
+)
+```
+
+### 5. Resume
+
+Return to the task that was interrupted by the signal. The friction
+is now in the wing; the Curator will pick it up on its next run.
+
+## Output expectations
+
+- A single `mempalace_add_drawer` MCP call to
+  `wing="harness-friction"`. Nothing else — no summary to the user,
+  no inline narration. The point of fire-and-forget is to keep the
+  flow.
+- If the user explicitly asked you to tag a friction, briefly confirm
+  it landed (one sentence). Otherwise stay silent.
+
+## Self-reporting bias
+
+A known weakness: the agent who produced the contested action is the
+one being asked to tag the friction. Rationalisation is easier than
+self-correction. To counteract this:
+
+- **When in doubt, tag.** Over-reporting is curatable; under-reporting
+  is lost forever. Curation cost is cheap relative to the cost of an
+  unflagged systemic friction.
+- **A user correction is always a recognition signal**, even when you
+  privately think "the user just changed their mind". The Curator
+  will downgrade if the cluster proves to be preference rather than
+  defect.
+
+## Friction reporting (recursive)
+
+If `harness-report` itself led to a malformed payload, a wrong
+attribution, or made you skip a tag that should have happened — tag
+it like any other friction, with `canonical` pointing at this skill's
+own URL. The reporter is not exempt from the loop it serves.

--- a/.gemini/skills/harness-report/SKILL.md
+++ b/.gemini/skills/harness-report/SKILL.md
@@ -35,7 +35,7 @@ short reminder list:
 - **Process gap** — a documented workflow step turned out to be
   missing, ambiguous, contradictory, or out of date.
 - **Safeguard friction** — a rule or guard blocked a legitimate action
-  and forced a workaround you had to justify.
+  and forced a workaround you had to explain explicitly to the user.
 
 If a signal fires, **tag the friction before resuming work**. Not
 "consider tagging". Not "when convenient". Tagging takes seconds and

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -113,9 +113,8 @@ Do not paste the entire PR description. The commit message is denser.
 
 ## Friction reporting
 
-Tag per `config/TOOLS.md` → *Friction Reporting* when:
-
-- The project's PR template is contradictory or out of date
-  (`room="process"`).
-- The skill produced a body that the user had to substantially rewrite
-  (`room="prompt"` or `room="format"` depending on the cause).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.gemini/skills/security/SKILL.md
+++ b/.gemini/skills/security/SKILL.md
@@ -106,11 +106,8 @@ When asked to review a dependency upgrade:
 
 ## Friction reporting
 
-Tag frictions per `config/TOOLS.md` → *Friction Reporting* when:
-
-- A security tool gave a false positive that wasted review cycles
-  (`room="tool"`).
-- The skill prompt missed a class of threat that surfaced anyway
-  (`room="prompt"`).
-- A project process step (e.g. dependency upgrade workflow) skipped a
-  required check (`room="process"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/.gemini/skills/tester/SKILL.md
+++ b/.gemini/skills/tester/SKILL.md
@@ -101,11 +101,8 @@ A test that never failed before the fix proves nothing.
 
 ## Friction reporting
 
-Tag per `config/TOOLS.md` → *Friction Reporting* when:
-
-- A test framework / runner has a sharp edge that wasted time
-  (`room="tool"`).
-- The project's test-writing convention is unclear or contradictory
-  (`room="process"`).
-- A skill prompt led you to write coverage-theatre tests
-  (`room="prompt"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/community-config/agents/architect/AGENT.md
+++ b/community-config/agents/architect/AGENT.md
@@ -30,5 +30,8 @@ If you find yourself producing a 2-page Context section for an ADR, the
 decision is not yet crisp. Stop, compress the context, then continue.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/community-config/agents/architect/AGENT.md
+++ b/community-config/agents/architect/AGENT.md
@@ -29,5 +29,6 @@ the user.
 If you find yourself producing a 2-page Context section for an ADR, the
 decision is not yet crisp. Stop, compress the context, then continue.
 
-Tag frictions per `config/TOOLS.md` whenever the architect skill itself
-led you down a wrong path or missed a blast-radius dimension.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/community-config/agents/developer/AGENT.md
+++ b/community-config/agents/developer/AGENT.md
@@ -34,5 +34,8 @@ When several subtasks are independent, dispatch them in parallel. When
 they share a file or a contract, serialise.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/community-config/agents/developer/AGENT.md
+++ b/community-config/agents/developer/AGENT.md
@@ -33,5 +33,6 @@ verification you did not perform.
 When several subtasks are independent, dispatch them in parallel. When
 they share a file or a contract, serialise.
 
-Tag frictions per `config/TOOLS.md` whenever a tool, a prompt, or a
-process step wasted cycles.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/community-config/agents/doc-writer/AGENT.md
+++ b/community-config/agents/doc-writer/AGENT.md
@@ -39,5 +39,6 @@ Before committing any document, you ask yourself which parts will be
 wrong in six months, and move those parts closer to the code if you
 can.
 
-Tag frictions per `config/TOOLS.md` when a doc template is contradictory
-or when you produced a doc the user had to substantially rewrite.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/community-config/agents/doc-writer/AGENT.md
+++ b/community-config/agents/doc-writer/AGENT.md
@@ -40,5 +40,8 @@ wrong in six months, and move those parts closer to the code if you
 can.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/community-config/agents/harness-curator/AGENT.md
+++ b/community-config/agents/harness-curator/AGENT.md
@@ -36,6 +36,6 @@ as malformed, clusters formed, clusters that hit threshold, MRs opened
 with links, routing failures.
 
 You are not exempt from the loop you serve. When a recognition signal
-fires (see `config/TOOLS.md` → *Friction Reporting*), invoke the
-`harness-report` skill — it is the single canonical implementation of
-the tagging protocol.
+fires (see `config/TOOLS.md` → *Friction Reporting → Recognition
+signals*), follow the procedure in the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`).

--- a/community-config/agents/harness-curator/AGENT.md
+++ b/community-config/agents/harness-curator/AGENT.md
@@ -35,6 +35,7 @@ You always end a run with a summary: frictions read, frictions skipped
 as malformed, clusters formed, clusters that hit threshold, MRs opened
 with links, routing failures.
 
-You are not exempt from the loop you serve. If your own behaviour
-produced a bad cluster or an unactionable MR, tag the friction per
-`config/TOOLS.md`.
+You are not exempt from the loop you serve. When a recognition signal
+fires (see `config/TOOLS.md` → *Friction Reporting*), invoke the
+`harness-report` skill — it is the single canonical implementation of
+the tagging protocol.

--- a/community-config/agents/pr-logbook/AGENT.md
+++ b/community-config/agents/pr-logbook/AGENT.md
@@ -36,5 +36,8 @@ the document that survives in `git log` forever, and compose it
 deliberately rather than pasting the PR description.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/community-config/agents/pr-logbook/AGENT.md
+++ b/community-config/agents/pr-logbook/AGENT.md
@@ -35,6 +35,6 @@ When the project squash-merges, you treat the squash commit message as
 the document that survives in `git log` forever, and compose it
 deliberately rather than pasting the PR description.
 
-Tag frictions per `config/TOOLS.md` when a project's PR template is
-contradictory or when you produced a body the user had to substantially
-rewrite.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/community-config/agents/security/AGENT.md
+++ b/community-config/agents/security/AGENT.md
@@ -35,5 +35,6 @@ You activate mandatorily on any change touching auth, secrets, crypto,
 external-input parsing, deserialisation, outbound network calls, or
 dependency upgrades on those surfaces.
 
-Tag frictions per `config/TOOLS.md` when a tool gives false positives
-or the skill prompt missed a class of threat.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/community-config/agents/security/AGENT.md
+++ b/community-config/agents/security/AGENT.md
@@ -36,5 +36,8 @@ external-input parsing, deserialisation, outbound network calls, or
 dependency upgrades on those surfaces.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/community-config/agents/tester/AGENT.md
+++ b/community-config/agents/tester/AGENT.md
@@ -34,6 +34,6 @@ If the project has no test infrastructure and the user has not asked
 for one, you say so and stop — do not invent a framework on the user's
 behalf.
 
-Tag frictions per `config/TOOLS.md` when the test runner has a sharp
-edge, the project's test-writing convention is unclear, or a skill
-prompt led you to coverage-theatre tests.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting*), invoke the `harness-report` skill — it is the
+single canonical implementation of the tagging protocol.

--- a/community-config/agents/tester/AGENT.md
+++ b/community-config/agents/tester/AGENT.md
@@ -35,5 +35,8 @@ for one, you say so and stop — do not invent a framework on the user's
 behalf.
 
 When a recognition signal fires (see `config/TOOLS.md` →
-*Friction Reporting*), invoke the `harness-report` skill — it is the
-single canonical implementation of the tagging protocol.
+*Friction Reporting → Recognition signals*), follow the procedure in
+the `harness-report` skill
+(`community-config/skills/harness-report/SKILL.md`). It is the single
+canonical implementation of the tagging protocol — do not reimplement
+inline.

--- a/community-config/skills/architect/SKILL.md
+++ b/community-config/skills/architect/SKILL.md
@@ -94,9 +94,8 @@ not been thought through yet.
 
 ## Friction reporting
 
-If the architecture skill itself led you down a wrong path (e.g. forced
-a heavyweight ADR on a trivial change, or missed a blast-radius
-dimension), tag it per `config/TOOLS.md` → *Friction Reporting*.
-
-Use `room="prompt"` (the prompt was misleading) or `room="process"`
-(the workflow itself has a gap).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/community-config/skills/developer/SKILL.md
+++ b/community-config/skills/developer/SKILL.md
@@ -92,11 +92,8 @@ independent — serialise them.
 
 ## Friction reporting
 
-Tag frictions per `config/TOOLS.md` → *Friction Reporting* whenever:
-
-- A skill prompt led you to a wrong implementation path
-  (`room="prompt"`).
-- A tool produced surprising or inconsistent behaviour
-  (`room="tool"`).
-- A documented step in the project's workflow is missing or ambiguous
-  (`room="process"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/community-config/skills/doc-writer/SKILL.md
+++ b/community-config/skills/doc-writer/SKILL.md
@@ -140,9 +140,8 @@ Standalone docs that drift silently are worse than no docs.
 
 ## Friction reporting
 
-Tag per `config/TOOLS.md` → *Friction Reporting* when:
-
-- A doc template (ADR, README scaffold) was contradictory or out of
-  date (`room="process"`).
-- The skill produced a doc the user had to substantially rewrite
-  (`room="prompt"` or `room="format"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/community-config/skills/harness-curator/SKILL.md
+++ b/community-config/skills/harness-curator/SKILL.md
@@ -149,7 +149,9 @@ run is worth reporting — it tells the user the wing is healthy.
 
 ## Friction reporting
 
-The Curator can itself produce friction. If the curation prompt led to
-a bad cluster, a wrong target, or an unactionable MR, tag per
-`config/TOOLS.md` → *Friction Reporting* with `room="prompt"` or
-`room="behavior"`. The Curator is not exempt from the loop it serves.
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The Curator is not exempt from the loop it serves — if the
+curation prompt led to a bad cluster, a wrong routing target, or an
+unactionable MR, report it like any other friction.

--- a/community-config/skills/harness-report/SKILL.md
+++ b/community-config/skills/harness-report/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: harness-report
+description: "Tag a friction encountered during real work. Activate the moment
+  any recognition signal fires (user pushback, second-time tool surprise,
+  sibling-skill workaround, etc.). The single canonical implementation of
+  the friction-tagging protocol — all other skills point here."
+type: skill
+provenance:
+  canonical: "${CANONICAL_REPO}"
+  feedback: "${FEEDBACK_REPO}"
+  version: "1.0.0"
+claude:
+  allowed-tools:
+    - Read
+  user-invocable: true
+---
+
+# Harness Report
+
+The skill every other skill invokes when a friction signal fires. The
+protocol contract (payload schema, wing routing, fixed categories,
+what NOT to tag) lives in `config/TOOLS.md` → *Friction Reporting*.
+This skill is the *operational* counterpart: how to recognise a
+signal, how to fill the payload correctly, and especially how to
+attribute the friction to the right offender even when you are not
+currently operating under that offender's skill.
+
+## When to activate
+
+The moment any recognition signal fires. Listed in canonical form in
+`config/TOOLS.md` → *Friction Reporting → Recognition signals*; the
+short reminder list:
+
+- **User pushback** — the user contests, corrects, or reverts the
+  action you just took, or reformulates the same intent because your
+  previous response was misaligned.
+- **Sibling-skill workaround** — you find yourself contorting around
+  a constraint set by another skill or agent, not the user's request.
+- **Tool surprise (second time)** — a tool produced surprising or
+  inconsistent behaviour for the second time in the same session.
+  First time is bad luck; second time is a pattern.
+- **Process gap** — a documented workflow step turned out to be
+  missing, ambiguous, contradictory, or out of date.
+- **Safeguard friction** — a rule or guard blocked a legitimate action
+  and forced a workaround you had to justify.
+
+If a signal fires, **tag the friction before resuming work**. Not
+"consider tagging". Not "when convenient". Tagging takes seconds and
+costs nothing; failing to tag loses the signal forever.
+
+## Operating mode
+
+### 1. Pause and identify the offender
+
+The trickiest part of friction reporting is **getting the attribution
+right**. You are likely operating under some skill X when the friction
+manifests, but the *offender* might be:
+
+- Skill X itself (its prompt led you astray).
+- A *different* skill or agent you read earlier in the session.
+- A document (`AGENTS.md`, a `config/*.md` file).
+- A tool (`gh`, `jq`, `yq`, an MCP server).
+- A process step in `config/TOOLS.md` or similar.
+
+Before composing the payload, ask yourself: *what specifically led to
+the contested action?* Trace the chain backwards from the action to
+its closest source. That source is the offender, and its URL or path
+belongs in `canonical:` — **never the path to this `harness-report`
+skill**, which is just the orchestrator.
+
+If you genuinely cannot pinpoint the offender, leave `canonical:`
+empty and let `evidence:` carry the trail. A routing failure (caught
+by the Curator at consumption time) is better than a wrong-target MR.
+
+### 2. Pick the room
+
+One of the 5 fixed categories per `config/TOOLS.md`:
+
+- `tool` — an MCP tool, CLI, or script behaved unexpectedly.
+- `prompt` — a skill/agent prompt was misleading or led you astray.
+- `format` — an output format broke parsing or mixed concerns.
+- `behavior` — an agent did something it should not have, or skipped
+  something it should have done.
+- `process` — a documented workflow step is missing or out of date.
+
+When in doubt between `prompt` and `behavior`: ask whether the prompt
+*told* you to do the wrong thing (→ `prompt`) or whether you went off
+the prompt's rails on your own (→ `behavior`).
+
+### 3. Fill the payload
+
+Mandatory fields (the script will skip the drawer if either is
+missing or empty):
+
+- `writer_agent` — your own identifier (`claude-code`, `gemini-cli`,
+  …). Non-empty.
+- ≥1 `evidence:` entry — at minimum a file path with line number; a
+  commit hash + path + line is better (the file may move but the
+  commit is permanent).
+
+Strongly encouraged:
+
+- `subcategory` — a free-form clustering anchor. Frictions sharing a
+  `subcategory` get bundled into the same MR by the Curator.
+- `canonical` — the canonical URL of the offending component (from
+  its own `provenance.canonical` block when available).
+- `severity` — `low` / `med` / `high`. Default `med`. Reserve `high`
+  for blockers; it bypasses the cluster threshold and forces an MR.
+- `suggestion` — what you think would fix it. The Curator weighs
+  clusters with suggestions higher.
+
+The full schema, including the inline `evidence: <single-value>`
+short form, lives in `config/TOOLS.md` → *Payload schema*. Do not
+re-derive it here; refer to it.
+
+### 4. Tag
+
+One MCP call. Fire and forget — do not wait for an acknowledgement,
+do not block, return to your task:
+
+```text
+mempalace_add_drawer(
+  wing="harness-friction",
+  room="<one of the 5 categories>",
+  content="""
+FRICTION: <one-line title>
+
+writer_agent: <you>
+subcategory: <optional anchor>
+canonical: <URL of offender, if known>
+severity: <low|med|high — default med>
+evidence:
+  - <commit_hash>:<path>:<line>
+  - <URL>
+suggestion: <optional fix idea>
+"""
+)
+```
+
+### 5. Resume
+
+Return to the task that was interrupted by the signal. The friction
+is now in the wing; the Curator will pick it up on its next run.
+
+## Output expectations
+
+- A single `mempalace_add_drawer` MCP call to
+  `wing="harness-friction"`. Nothing else — no summary to the user,
+  no inline narration. The point of fire-and-forget is to keep the
+  flow.
+- If the user explicitly asked you to tag a friction, briefly confirm
+  it landed (one sentence). Otherwise stay silent.
+
+## Self-reporting bias
+
+A known weakness: the agent who produced the contested action is the
+one being asked to tag the friction. Rationalisation is easier than
+self-correction. To counteract this:
+
+- **When in doubt, tag.** Over-reporting is curatable; under-reporting
+  is lost forever. Curation cost is cheap relative to the cost of an
+  unflagged systemic friction.
+- **A user correction is always a recognition signal**, even when you
+  privately think "the user just changed their mind". The Curator
+  will downgrade if the cluster proves to be preference rather than
+  defect.
+
+## Friction reporting (recursive)
+
+If `harness-report` itself led to a malformed payload, a wrong
+attribution, or made you skip a tag that should have happened — tag
+it like any other friction, with `canonical` pointing at this skill's
+own URL. The reporter is not exempt from the loop it serves.

--- a/community-config/skills/harness-report/SKILL.md
+++ b/community-config/skills/harness-report/SKILL.md
@@ -42,7 +42,7 @@ short reminder list:
 - **Process gap** — a documented workflow step turned out to be
   missing, ambiguous, contradictory, or out of date.
 - **Safeguard friction** — a rule or guard blocked a legitimate action
-  and forced a workaround you had to justify.
+  and forced a workaround you had to explain explicitly to the user.
 
 If a signal fires, **tag the friction before resuming work**. Not
 "consider tagging". Not "when convenient". Tagging takes seconds and

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -121,9 +121,8 @@ Do not paste the entire PR description. The commit message is denser.
 
 ## Friction reporting
 
-Tag per `config/TOOLS.md` → *Friction Reporting* when:
-
-- The project's PR template is contradictory or out of date
-  (`room="process"`).
-- The skill produced a body that the user had to substantially rewrite
-  (`room="prompt"` or `room="format"` depending on the cause).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/community-config/skills/security/SKILL.md
+++ b/community-config/skills/security/SKILL.md
@@ -116,11 +116,8 @@ When asked to review a dependency upgrade:
 
 ## Friction reporting
 
-Tag frictions per `config/TOOLS.md` → *Friction Reporting* when:
-
-- A security tool gave a false positive that wasted review cycles
-  (`room="tool"`).
-- The skill prompt missed a class of threat that surfaced anyway
-  (`room="prompt"`).
-- A project process step (e.g. dependency upgrade workflow) skipped a
-  required check (`room="process"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/community-config/skills/tester/SKILL.md
+++ b/community-config/skills/tester/SKILL.md
@@ -113,11 +113,8 @@ A test that never failed before the fix proves nothing.
 
 ## Friction reporting
 
-Tag per `config/TOOLS.md` → *Friction Reporting* when:
-
-- A test framework / runner has a sharp edge that wasted time
-  (`room="tool"`).
-- The project's test-writing convention is unclear or contradictory
-  (`room="process"`).
-- A skill prompt led you to write coverage-theatre tests
-  (`room="prompt"`).
+When a recognition signal fires (see `config/TOOLS.md` →
+*Friction Reporting → Recognition signals*), invoke the
+`harness-report` skill rather than reimplementing the protocol
+inline. The reporter walks you through identifying the offender,
+picking the room, and filling the payload.

--- a/config/TOOLS.md
+++ b/config/TOOLS.md
@@ -403,7 +403,8 @@ one source of truth.
 4. **Process gap.** A documented workflow step turned out to be
    missing, ambiguous, contradictory, or out of date.
 5. **Safeguard friction.** A rule or guard blocked a legitimate
-   action and forced a workaround you had to justify in prose.
+   action and forced a workaround you had to explain explicitly to
+   the user.
 
 When any signal fires, **tag the friction before resuming work** —
 not "consider tagging", not "when convenient". The fire-and-forget

--- a/config/TOOLS.md
+++ b/config/TOOLS.md
@@ -377,21 +377,49 @@ in each component's `provenance:` block.
 
 ### When to tag
 
-Tag a friction whenever you notice one. Do not pause the user's task.
-The cost of one tag is negligible; the cost of an un-reported friction
-that bites the next agent is much higher.
-
-Concrete triggers:
-
-- A skill or agent prompt led you to a wrong path you had to back out.
-- An output format from another agent broke a downstream tool or parse.
-- A tool invocation produced surprising or inconsistent behaviour.
-- A documented process step turned out to be missing, ambiguous, or
-  out of date.
-- A safeguard / rule blocked a legitimate action and forced a workaround.
+Tag a friction whenever a **recognition signal** fires (next section).
+Do not pause the user's task longer than the tag itself. The cost of
+one tag is negligible; the cost of an un-reported friction that bites
+the next agent is much higher.
 
 If unsure whether something qualifies — tag it. Curation will discard
 noise; silent friction is the failure mode to avoid.
+
+### Recognition signals
+
+These are the canonical signals that **must** trigger a tag. They are
+listed here, not duplicated across every skill, so the contract has
+one source of truth.
+
+1. **User pushback.** The user contests, corrects, or reverts the
+   action you just took, or reformulates the same intent because your
+   previous response was misaligned.
+2. **Sibling-skill workaround.** You find yourself contorting around
+   a constraint set by another skill or agent — not by the user's
+   request.
+3. **Tool surprise (second time).** A tool produced surprising or
+   inconsistent behaviour for the second time in the same session.
+   First time is bad luck; second time is a pattern.
+4. **Process gap.** A documented workflow step turned out to be
+   missing, ambiguous, contradictory, or out of date.
+5. **Safeguard friction.** A rule or guard blocked a legitimate
+   action and forced a workaround you had to justify in prose.
+
+When any signal fires, **tag the friction before resuming work** —
+not "consider tagging", not "when convenient". The fire-and-forget
+property qualifies the *transport* (no ack expected); it does not
+make the trigger optional.
+
+### How to tag — the `harness-report` skill
+
+The operational procedure (identifying the offender, picking the
+room, filling the payload) lives in
+`community-config/skills/harness-report/SKILL.md`. Any skill or
+agent that needs to tag a friction must invoke `harness-report`
+rather than re-implementing the protocol inline. This keeps the
+contract single-sourced and lets future improvements (richer
+`evidence:` format, new recognition signals, etc.) propagate without
+editing every skill body.
 
 ### Where to write
 


### PR DESCRIPTION
Surfaced during a design-loop discussion on #41: the friction-reporting protocol was duplicated across the 7 V0 skills, the recognition signals were not named explicitly (especially user pushback — the most common one), and there was no single owner of the contract. This PR centralises everything in one skill.

## How to read this PR?

Three layers, in order:

1. **`community-config/skills/harness-report/SKILL.md`** (new) — the canonical implementation. Names the 5 recognition signals, walks the caller through attribution (critical: the agent is often operating under a *different* skill when the friction occurs, and must point `canonical:` at the offender, not at `harness-report`), payload filling, and the single MCP call. Includes a section on self-reporting bias and a recursive friction clause.
2. **`config/TOOLS.md`** — Friction Reporting section gains a *Recognition signals* subsection (the protocol layer) and a *How to tag — the `harness-report` skill* paragraph that points at the operational layer. The existing payload schema, field semantics, and what-NOT-to-tag stays unchanged.
3. **The 7 existing skills + 7 agents** — each Friction reporting section shrinks to a single paragraph pointing at `harness-report`. The skill-specific bullet lists ("when the architect prompt led you astray", "when a security tool gave false positives", etc.) are removed — they were duplicated, drift-prone, and contributed nothing the recognition signals don't already cover.

Non-obvious decisions:

- **Recognition signals live in `TOOLS.md`, not in `harness-report/SKILL.md`.** The protocol layer (*what counts as a friction*) belongs in the universal contract document, where all agents inherit it. The skill is the *operational* layer (*how to apply the protocol once a signal fires*). This split prevents future divergence between "what is a friction" and "how to report one".
- **No `harness-report` agent.** Unlike `harness-curator`, the reporter is invoked inline by other skills/agents in the middle of their existing work — not as a standalone subagent for a dedicated orchestration. A future ticket can add an agent if real usage shows a need.
- **"User pushback" is now named explicitly.** Previously the closest the prose got was "agents tag frictions when they notice them" — relying on the agent to self-recognise that "the user just contested my action" qualifies. Naming the signal makes the obligation falsifiable.
- **Self-reporting bias is acknowledged in the skill body.** A short paragraph warns the agent that rationalisation is easier than self-correction and instructs "when in doubt, tag — over-reporting is curatable, under-reporting is lost forever".

## How to test this PR?

Prerequisites: `bash`, `python3`, `yq`, `jq`.

```bash
# 1. Round-trip clean.
task build-components
git diff --quiet || echo "(unexpected drift)"

# 2. Drift detection passes.
task check-components
# Expect: "OK: All generated files match source."

# 3. The new skill is built for both CLIs.
ls .gemini/skills/harness-report/SKILL.md .claude/skills/harness-report/SKILL.md

# 4. None of the 7 V0 skills/agents still re-implement the protocol inline.
grep -rn 'Tag frictions per' community-config/ || echo "(clean — no inline reimplementations left)"

# 5. The recognition signals are reachable from the contract document.
grep -A2 'Recognition signals' config/TOOLS.md | head

# 6. Curator smoke test still green (this PR does not touch the consumer side).
task test-harness-curate
# Expect: 18 PASS lines.
```

## Detailed description (for agents)

### Added: `community-config/skills/harness-report/SKILL.md`

`harness-report` is the canonical friction-reporting skill. Its body has five sections:

- *When to activate* — references the canonical Recognition signals list in `config/TOOLS.md`, repeats the short reminder list for ergonomics.
- *Operating mode → Pause and identify the offender* — the attribution rules. Critical paragraph: the agent is often operating under skill X when a friction caused by skill Y manifests; `canonical:` must point at Y, never at `harness-report`. If the offender cannot be identified, `canonical:` stays empty and `evidence:` carries the trail (routing failure at consumption time beats wrong-target MR).
- *Operating mode → Pick the room* — one of the 5 fixed categories, with a disambiguation tip for `prompt` vs `behavior`.
- *Operating mode → Fill the payload* — mandatory `writer_agent` (non-empty) + ≥1 `evidence:` entry; encouraged `subcategory`, `canonical`, `severity`, `suggestion`. Schema reference points back to `TOOLS.md`.
- *Operating mode → Tag, then Resume* — one MCP call, no narration to the user unless asked.

### Modified: `config/TOOLS.md`

- *When to tag* paragraph trimmed; concrete triggers removed (they overlapped with Recognition signals).
- New *Recognition signals* subsection — 5 numbered signals, names them in canonical form, ends with the falsifiable obligation "tag the friction before resuming work".
- New *How to tag — the `harness-report` skill* paragraph: explicit pointer at the skill as the single operational entry point, motivated by the single-source-of-truth principle.

### Modified: 7 skills + 7 agents

Each previously had a custom *Friction reporting* section with skill-specific bullets. Now each has the same paragraph: "When a recognition signal fires (see `config/TOOLS.md` → *Friction Reporting → Recognition signals*), invoke the `harness-report` skill rather than reimplementing the protocol inline."

The `harness-curator` skill preserves its meta-comment ("the Curator is not exempt from the loop it serves") but now routes through `harness-report`.

### Out of scope (potential follow-ups)

- **Automated friction capture.** No CLI-level hook detects "user pushback" in the transcript and triggers `harness-report` automatically. Trigger remains agent-initiated, now with explicit and falsifiable signals. A future ticket could explore a Claude Code / Gemini CLI hook surface if upstream exposes one.
- **`evidence:` with commit hash + path + line.** Currently the field is free-form. A future iteration could enforce or strongly encourage the tuple `<commit_hash>:<path>:<line>` so references survive file moves. Logged for revisit.
- **A `harness-report` agent** symmetrical with `harness-curator`. Not added in this PR; the reporter is meant to be invoked inline by other skills, not as a standalone subagent.