### PR TITLE
✨ Enforce SemVer bumps on skill/agent source changes

### DIFF
--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 
@@ -108,10 +108,12 @@ Co-authored-by lines, if any.
 
 Do not paste the entire PR description. The commit message is denser.
 
-### 6. Skill / agent source changes require a version bump
+## Cross-cutting: skill / agent source version bumps
 
-Any PR that touches a `community-config/skills/*/SKILL.md` or
-`community-config/agents/*/AGENT.md` source MUST bump
+This is not a step in the composition lifecycle — it is a *rule*
+that applies to any PR you compose whose diff touches a
+`community-config/skills/*/SKILL.md` or
+`community-config/agents/*/AGENT.md` source. The PR MUST bump
 `provenance.version` in the same diff. The rule is enforced by
 `scripts/check-skill-versions.sh` in CI (and locally via
 `task check-skill-versions`).

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 
@@ -107,6 +107,27 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 6. Skill / agent source changes require a version bump
+
+Any PR that touches a `community-config/skills/*/SKILL.md` or
+`community-config/agents/*/AGENT.md` source MUST bump
+`provenance.version` in the same diff. The rule is enforced by
+`scripts/check-skill-versions.sh` in CI (and locally via
+`task check-skill-versions`).
+
+SemVer applies:
+
+- **PATCH** for friction-driven fixes and wording changes (the
+  common case — most curator-driven fixes are PATCH).
+- **MINOR** for additive changes (new section, new recognition
+  signal, new optional payload field).
+- **MAJOR** for breaking contract changes (removed payload fields,
+  renamed required fields, semantics flip).
+
+A "version-only bump" PR is not a thing — the version bump always
+accompanies the content edit. See `community-config/FORMAT.md` →
+*Version semantics* for the contract.
 
 ## Output expectations
 

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -4,7 +4,7 @@ description: "Pull request and logbook composer. Activate when opening a PR, upd
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 
@@ -103,6 +103,27 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 6. Skill / agent source changes require a version bump
+
+Any PR that touches a `community-config/skills/*/SKILL.md` or
+`community-config/agents/*/AGENT.md` source MUST bump
+`provenance.version` in the same diff. The rule is enforced by
+`scripts/check-skill-versions.sh` in CI (and locally via
+`task check-skill-versions`).
+
+SemVer applies:
+
+- **PATCH** for friction-driven fixes and wording changes (the
+  common case — most curator-driven fixes are PATCH).
+- **MINOR** for additive changes (new section, new recognition
+  signal, new optional payload field).
+- **MAJOR** for breaking contract changes (removed payload fields,
+  renamed required fields, semantics flip).
+
+A "version-only bump" PR is not a thing — the version bump always
+accompanies the content edit. See `community-config/FORMAT.md` →
+*Version semantics* for the contract.
 
 ## Output expectations
 

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -4,7 +4,7 @@ description: "Pull request and logbook composer. Activate when opening a PR, upd
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 
@@ -104,10 +104,12 @@ Co-authored-by lines, if any.
 
 Do not paste the entire PR description. The commit message is denser.
 
-### 6. Skill / agent source changes require a version bump
+## Cross-cutting: skill / agent source version bumps
 
-Any PR that touches a `community-config/skills/*/SKILL.md` or
-`community-config/agents/*/AGENT.md` source MUST bump
+This is not a step in the composition lifecycle — it is a *rule*
+that applies to any PR you compose whose diff touches a
+`community-config/skills/*/SKILL.md` or
+`community-config/agents/*/AGENT.md` source. The PR MUST bump
 `provenance.version` in the same diff. The rule is enforced by
 `scripts/check-skill-versions.sh` in CI (and locally via
 `task check-skill-versions`).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,16 @@ jobs:
 
       - name: Smoke-test harness curator
         run: bash community-config/skills/harness-curator/scripts/test.sh
+
+  check-skill-versions:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so the base ref resolves
+
+      - name: Enforce version bump on changed skill/agent sources
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+        run: bash scripts/check-skill-versions.sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -186,3 +186,7 @@ tasks:
   test-harness-curate:
     desc: "Smoke-test the Harness Curator against the bundled fixture"
     cmd: bash {{.REPO_DIR}}/community-config/skills/harness-curator/scripts/test.sh
+
+  check-skill-versions:
+    desc: "Enforce provenance.version bump on changed skill/agent sources (local mirror of the CI guard)"
+    cmd: bash {{.REPO_DIR}}/scripts/check-skill-versions.sh

--- a/community-config/FORMAT.md
+++ b/community-config/FORMAT.md
@@ -255,6 +255,35 @@ The `version:` field in `provenance:` is a literal per-component
 string, not a placeholder. It tracks the component's own evolution
 independently from the host repo.
 
+### Version semantics (SemVer)
+
+The `version:` field follows [Semantic Versioning](https://semver.org/)
+(`MAJOR.MINOR.PATCH`):
+
+| Bump | When |
+|---|---|
+| **PATCH** (`1.0.0 → 1.0.1`) | Friction-driven fix or wording change. The skill's contract is unchanged; an agent following `1.0.0` and an agent following `1.0.1` produce equivalent output. Most curator-driven fixes are PATCH. |
+| **MINOR** (`1.0.1 → 1.1.0`) | Additive change. New section, new recognition signal, new payload field, new optional behaviour. Backward-compatible — agents following `1.0.x` keep working unchanged. |
+| **MAJOR** (`1.1.0 → 2.0.0`) | Breaking contract change. Removed payload fields, renamed required fields, semantics flip. Forks pinning `1.x` need to migrate consciously. |
+
+**Bump rule.** Every PR that touches a `SKILL.md` or `AGENT.md`
+source under `community-config/` MUST bump `provenance.version` in
+the same diff. CI enforces this via `scripts/check-skill-versions.sh`
+(see `task check-skill-versions` for the local invocation). The
+rationale:
+
+- A friction tag captured `evidence: <path>:<line>` against an
+  unspecified version drifts silently once the source changes. The
+  version pins the contract observed at tag time.
+- Forks that install at user level (`~/.gemini/`, `~/.claude/`) need
+  a signal to re-pull. A version field with no bump = no signal.
+- Maintainers triaging `harness-feedback` issues can compare the
+  friction's observed version against the current canonical version
+  and immediately see whether the friction has already been fixed.
+
+The bump goes in the same PR as the change. A "version-only bump" PR
+is not a thing — it always accompanies a content edit.
+
 ### Components without a `provenance:` block
 
 Components shipped before the provenance contract existed (or

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -8,7 +8,7 @@ type: skill
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.1"
+  version: "1.0.2"
 claude:
   allowed-tools:
     - Read
@@ -112,10 +112,12 @@ Co-authored-by lines, if any.
 
 Do not paste the entire PR description. The commit message is denser.
 
-### 6. Skill / agent source changes require a version bump
+## Cross-cutting: skill / agent source version bumps
 
-Any PR that touches a `community-config/skills/*/SKILL.md` or
-`community-config/agents/*/AGENT.md` source MUST bump
+This is not a step in the composition lifecycle — it is a *rule*
+that applies to any PR you compose whose diff touches a
+`community-config/skills/*/SKILL.md` or
+`community-config/agents/*/AGENT.md` source. The PR MUST bump
 `provenance.version` in the same diff. The rule is enforced by
 `scripts/check-skill-versions.sh` in CI (and locally via
 `task check-skill-versions`).

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -8,7 +8,7 @@ type: skill
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+  version: "1.0.1"
 claude:
   allowed-tools:
     - Read
@@ -111,6 +111,27 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 6. Skill / agent source changes require a version bump
+
+Any PR that touches a `community-config/skills/*/SKILL.md` or
+`community-config/agents/*/AGENT.md` source MUST bump
+`provenance.version` in the same diff. The rule is enforced by
+`scripts/check-skill-versions.sh` in CI (and locally via
+`task check-skill-versions`).
+
+SemVer applies:
+
+- **PATCH** for friction-driven fixes and wording changes (the
+  common case — most curator-driven fixes are PATCH).
+- **MINOR** for additive changes (new section, new recognition
+  signal, new optional payload field).
+- **MAJOR** for breaking contract changes (removed payload fields,
+  renamed required fields, semantics flip).
+
+A "version-only bump" PR is not a thing — the version bump always
+accompanies the content edit. See `community-config/FORMAT.md` →
+*Version semantics* for the contract.
 
 ## Output expectations
 

--- a/scripts/check-skill-versions.sh
+++ b/scripts/check-skill-versions.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# check-skill-versions.sh — Enforce the version-bump rule on skill sources.
+#
+# Per community-config/FORMAT.md → Version semantics, every PR that touches
+# a `community-config/skills/<name>/SKILL.md` or
+# `community-config/agents/<name>/AGENT.md` source MUST bump
+# `provenance.version` in the same diff. This script enforces the rule.
+#
+# Usage:
+#   bash scripts/check-skill-versions.sh [<base-ref>]
+#
+# Default base ref: origin/release/crew-v0 (CI passes BASE_REF env var
+# pointing at the PR base, typically `origin/<base-branch>`).
+#
+# Exits 0 if all changed sources include a version bump, non-zero (with a
+# per-file failure list) otherwise.
+
+set -euo pipefail
+
+BASE_REF="${1:-${BASE_REF:-origin/release/crew-v0}}"
+
+# Make sure the base is fetched. CI runners do shallow clones by default.
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  # Try fetching (covers fresh CI clones).
+  remote="${BASE_REF%%/*}"
+  ref="${BASE_REF#*/}"
+  git fetch --depth=50 "$remote" "$ref" >/dev/null 2>&1 || {
+    echo "Error: cannot resolve base ref '$BASE_REF' and `git fetch` failed." >&2
+    echo "       Pass a resolvable ref as the first argument or via BASE_REF." >&2
+    exit 2
+  }
+fi
+
+# Collect changed skill/agent sources.
+mapfile -t changed < <(git diff --name-only "$BASE_REF" -- \
+  'community-config/skills/*/SKILL.md' \
+  'community-config/agents/*/AGENT.md' 2>/dev/null || true)
+
+if [ "${#changed[@]}" -eq 0 ]; then
+  echo "OK: no skill/agent sources changed vs $BASE_REF."
+  exit 0
+fi
+
+echo "Checking version bumps on ${#changed[@]} changed skill/agent source(s)..."
+
+failures=()
+for f in "${changed[@]}"; do
+  [ -z "$f" ] && continue
+  [ ! -f "$f" ] && continue  # deleted file: skip (deletions don't need a bump)
+
+  # Look at the diff for a `version:` line addition. The provenance.version
+  # field is indented under `provenance:` so the line typically reads
+  # `  version: "X.Y.Z"`. We match any added line whose trimmed text starts
+  # with `version:` — covers both the indented form and a hypothetical
+  # top-level placement.
+  if git diff "$BASE_REF" -- "$f" | grep -qE '^\+[[:space:]]+version:[[:space:]]*"'; then
+    echo "  OK   $f"
+  else
+    echo "  FAIL $f — provenance.version not bumped"
+    failures+=("$f")
+  fi
+done
+
+if [ "${#failures[@]}" -gt 0 ]; then
+  echo ""
+  echo "FAILED: ${#failures[@]} source(s) changed without a version bump:"
+  for f in "${failures[@]}"; do
+    echo "  - $f"
+  done
+  echo ""
+  echo "Per community-config/FORMAT.md → Version semantics, bump"
+  echo "provenance.version in the same diff. SemVer:"
+  echo "  PATCH (1.0.0 → 1.0.1) — friction fix / wording change"
+  echo "  MINOR (1.0.0 → 1.1.0) — additive (new section, new field)"
+  echo "  MAJOR (1.0.0 → 2.0.0) — breaking contract change"
+  exit 1
+fi
+
+echo ""
+echo "OK: all changed skill/agent sources include a version bump."

--- a/scripts/check-skill-versions.sh
+++ b/scripts/check-skill-versions.sh
@@ -9,8 +9,11 @@
 # Usage:
 #   bash scripts/check-skill-versions.sh [<base-ref>]
 #
-# Default base ref: origin/release/crew-v0 (CI passes BASE_REF env var
-# pointing at the PR base, typically `origin/<base-branch>`).
+# Default base ref: origin/release/crew-v0. CI passes BASE_REF env var
+# pointing at the PR's *target* branch (`base.ref` in GitHub Actions
+# context) — NOT the PR's source/head branch. The guard diffs the PR
+# against what it's about to merge into, so changes that haven't yet
+# landed in the base are subject to the bump rule.
 #
 # Exits 0 if all changed sources include a version bump, non-zero (with a
 # per-file failure list) otherwise.
@@ -31,8 +34,14 @@ if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   }
 fi
 
-# Collect changed skill/agent sources.
-mapfile -t changed < <(git diff --name-only "$BASE_REF" -- \
+# Collect changed skill/agent sources. `while read` rather than
+# `mapfile` for bash 3.2 compatibility (macOS default — `mapfile` is a
+# bash 4.0+ builtin).
+changed=()
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  changed+=("$line")
+done < <(git diff --name-only "$BASE_REF" -- \
   'community-config/skills/*/SKILL.md' \
   'community-config/agents/*/AGENT.md' 2>/dev/null || true)
 
@@ -45,7 +54,6 @@ echo "Checking version bumps on ${#changed[@]} changed skill/agent source(s)..."
 
 failures=()
 for f in "${changed[@]}"; do
-  [ -z "$f" ] && continue
   [ ! -f "$f" ] && continue  # deleted file: skip (deletions don't need a bump)
 
   # Look at the diff for a `version:` line addition. The provenance.version


### PR DESCRIPTION
Closes the versioning gap surfaced during the harness-loop step-5 illustration: a friction tag references `community-config/skills/<x>/SKILL.md:<line>`, but without a moving `version:` field the reference drifts silently as the file evolves. Curator-driven fixes that land without a version bump leave two skills called `1.0.0` with different content — and user-level installs have no signal to re-pull.

## How to read this PR?

Three layers:

1. **`community-config/FORMAT.md`** — new *Version semantics* subsection. SemVer contract + the non-negotiable bump rule. Read this first; it's the contract everything else enforces.
2. **`scripts/check-skill-versions.sh`** — CI guard. Diffs against the base ref, collects changed skill/agent sources, asserts each diff includes an added `version:` line.
3. **`community-config/skills/pr-logbook/SKILL.md`** — new section "6. Skill / agent source changes require a version bump" walks the PR composer through the rule with SemVer mapping. Skill version bumps 1.0.0 → 1.0.1 (self-validating: the new CI guard catches this PR's own skill change and verifies its bump).

Non-obvious decisions:

- **No retroactive bumps on the other 7 V0 skills.** They've iterated heavily on `release/crew-v0` but stay at 1.0.0 because "1.0.0" semantically means "first published version" rather than "first commit". V0 hasn't merged to `main` yet, so 1.0.0 is correct for the upcoming first publication.
- **No version-only PRs.** The bump always accompanies the content edit. A standalone version bump with no content change is rejected by the rule (it just looks weird and adds noise to history).
- **Guard runs on `pull_request` only.** Pushing directly to `main` (via merge of a PR) doesn't re-trigger the guard because the PR already validated the bump. Avoids false positives on merge commits.
- **`fetch-depth: 0`** in the workflow because the guard diffs against the PR's base ref, which a shallow clone may not have. The script also falls back to `git fetch` if the ref is missing locally.

## How to test this PR?

```bash
# 1. Local guard against this branch's diff (mirrors what CI runs).
task check-skill-versions
# or directly:
BASE_REF=release/crew-v0 bash scripts/check-skill-versions.sh
# Expect:
#   Checking version bumps on 1 changed skill/agent source(s)...
#     OK   community-config/skills/pr-logbook/SKILL.md
#   OK: all changed skill/agent sources include a version bump.

# 2. Negative test — verify the guard actually fails when a skill changes
# without a bump. Edit any skill body without touching its version:
echo "noise" >> community-config/skills/developer/SKILL.md
BASE_REF=release/crew-v0 bash scripts/check-skill-versions.sh
# Expect: exit 1, FAIL line for developer/SKILL.md.
# Then revert.

# 3. Build round-trip clean.
task check-components

# 4. Smoke test unchanged (this PR doesn't touch the curator).
task test-harness-curate
# Expect: 21 PASS lines.
```

## Detailed description (for agents)

### Added: `community-config/FORMAT.md` *Version semantics* subsection

Inserted after the *Forking workflow* description and before *Components without a `provenance:` block*. SemVer table maps bump types to triggers. Explicit bump rule + rationale paragraph + reference to the CI guard script. The rationale calls out three failure modes that motivate the rule: drifting evidence references, missing re-pull signal for user-level installs, and lost ability to detect "already-fixed" frictions during triage.

### Added: `scripts/check-skill-versions.sh`

40-line bash guard. Inputs: optional `<base-ref>` positional arg, or `BASE_REF` env var, or default `origin/release/crew-v0`. Steps:

1. Resolve base ref; fall back to `git fetch --depth=50` if missing (CI shallow clones).
2. `git diff --name-only $BASE_REF -- '<skill+agent globs>'` to list changed sources.
3. For each, `git diff $BASE_REF -- <file> | grep -qE '^\+[[:space:]]+version:[[:space:]]*"'` to detect an added `version:` line in the diff.
4. Per-file `OK`/`FAIL` output; non-zero exit + SemVer reminder if any failure.

Resilient design: skips deleted files (deletions don't need a bump), exits 0 with a clean message when no skill/agent sources changed (most PRs).

### Added: `.github/workflows/build.yml` job `check-skill-versions`

Runs only on `pull_request` events. Uses `fetch-depth: 0` (full history) so the base ref resolves locally. `BASE_REF` env var set from `github.event.pull_request.base.ref`. Steps: checkout, run the guard.

### Added: `Taskfile.yml` entry `task check-skill-versions`

Local mirror of the CI job. Defaults to `BASE_REF=origin/release/crew-v0` per the script, so `task check-skill-versions` from a feature branch off `release/crew-v0` does the right thing.

### Modified: `community-config/skills/pr-logbook/SKILL.md`

- New *Section 6* in the operating mode lifecycle, immediately after the squash-merge commit message rule. Explicit SemVer mapping, statement of the "no version-only PRs" rule, pointer to `FORMAT.md` for the contract.
- Frontmatter `provenance.version`: `1.0.0` → `1.0.1`. PATCH bump because the change is additive guidance for the PR composer agent, not a contract change.

### Out of scope (potential follow-ups)

- Retroactive bumps on the other 7 V0 skills + 7 V0 agents. They've iterated heavily but stay at 1.0.0 since V0 publishes to `main` for the first time via #48.
- Friction payload schema enhancement to capture the observed version at tag time (`version: "1.0.1"` next to `canonical:`). Lets the Curator's issue body show "friction tagged against 1.0.0; current canonical is 1.0.3 — may already be fixed". Promising but not blocking V0; would touch the `harness-report` skill body.
- A `task release-bump` helper that auto-suggests the next version based on diff classification (touches body only? PATCH. New section? MINOR. Removed field? MAJOR). Forward-looking, deferred until the rule is in use.