### PR TITLE
♻️ Extract Curator --apply heredoc into apply.py (#57)

### DIFF
--- a/.claude/skills/harness-curator/scripts/apply.py
+++ b/.claude/skills/harness-curator/scripts/apply.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""harness_curate — Apply step.
+
+Reads the cluster JSON emitted by ``curate.py`` on stdin and either opens
+one GitHub issue per cluster via ``gh issue create`` (default) or, with
+``--dry-run-apply``, prints the resolved ``gh`` argv as one JSON line per
+cluster without running anything.
+
+The script is invoked by ``curate.sh`` through ``$MEMPALACE_PYTHON``
+rather than via shebang exec, so that any future ``from mempalace …``
+import resolves against the same interpreter that ``curate.py`` uses.
+The ``#!/usr/bin/env python3`` shebang above is kept so a human can still
+run the script standalone for debugging.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def _build_cmd(cluster: dict) -> list[str]:
+    target = cluster["target_repo"]
+    title = cluster["title"]
+    body = cluster["body"]
+    labels = cluster.get("labels", ["harness-feedback"])
+    cmd = [
+        "gh", "issue", "create",
+        "--repo", target.replace("https://github.com/", ""),
+        "--title", title,
+        "--body", body,
+    ]
+    for lbl in labels:
+        cmd.extend(["--label", lbl])
+    return cmd
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run-apply",
+        action="store_true",
+        help="Print the resolved gh argv per cluster as JSON lines and exit 0.",
+    )
+    args = parser.parse_args()
+
+    data = json.load(sys.stdin)
+    clusters = data.get("clusters", [])
+    if not clusters:
+        print("No clusters above threshold; no issues to open.")
+        return 0
+
+    if args.dry_run_apply:
+        for c in clusters:
+            print(json.dumps(_build_cmd(c)))
+        return 0
+
+    opened = []
+    failures = []
+    for c in clusters:
+        target = c["target_repo"]
+        title = c["title"]
+        print(f"--- Opening issue on {target}: {title}")
+        cmd = _build_cmd(c)
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            opened.append({"cluster": c["cluster_key"], "url": result.stdout.strip()})
+        except subprocess.CalledProcessError as e:
+            failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
+
+    print()
+    print(f"Opened: {len(opened)} issue(s)")
+    for o in opened:
+        print(f"  - {o['cluster']}: {o['url']}")
+    if failures:
+        print(f"Failures: {len(failures)}", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f['cluster']}: {f['error']}", file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/harness-curator/scripts/curate.sh
+++ b/.claude/skills/harness-curator/scripts/curate.sh
@@ -98,9 +98,11 @@ command -v "$MEMPALACE_PYTHON" >/dev/null 2>&1 || {
 }
 
 # --- Run the curator ---
-# Read stdin into a tempfile if applicable so the python heredoc can re-open
-# it; passing stdin straight to the heredoc works on bash but fails when the
-# script is sourced or run under unusual launchers.
+# Read stdin into a tempfile if applicable so curate.py can re-open it;
+# passing stdin straight through works on bash but fails when the script
+# is sourced or run under unusual launchers. The tempfile + trap stays
+# here (not in apply.py) because the stdin payload feeds curate.py, not
+# apply.py, and the cleanup must outlive both python subprocesses.
 STDIN_FILE=""
 if [ "$FROM_STDIN" = true ]; then
   STDIN_FILE=$(mktemp -t crewrig-curate.XXXXXX)
@@ -129,43 +131,7 @@ command -v gh >/dev/null 2>&1 || {
   exit 3
 }
 
-# Parse JSON and open one issue per cluster.
-echo "$CURATE_OUT" | "$MEMPALACE_PYTHON" -c '
-import json, os, subprocess, sys
-
-data = json.load(sys.stdin)
-clusters = data.get("clusters", [])
-if not clusters:
-    print("No clusters above threshold; no issues to open.")
-    sys.exit(0)
-
-opened = []
-failures = []
-for c in clusters:
-    target = c["target_repo"]
-    title = c["title"]
-    body = c["body"]
-    labels = c.get("labels", ["harness-feedback"])
-    print(f"--- Opening issue on {target}: {title}")
-    cmd = ["gh", "issue", "create",
-           "--repo", target.replace("https://github.com/", ""),
-           "--title", title,
-           "--body", body]
-    for lbl in labels:
-        cmd.extend(["--label", lbl])
-    try:
-        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-        opened.append({"cluster": c["cluster_key"], "url": result.stdout.strip()})
-    except subprocess.CalledProcessError as e:
-        failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
-
-print()
-print(f"Opened: {len(opened)} issue(s)")
-for o in opened:
-    print(f"  - {o[\"cluster\"]}: {o[\"url\"]}")
-if failures:
-    print(f"Failures: {len(failures)}", file=sys.stderr)
-    for f in failures:
-        print(f"  - {f[\"cluster\"]}: {f[\"error\"]}", file=sys.stderr)
-    sys.exit(4)
-'
+# Parse JSON and open one issue per cluster. Invoke via $MEMPALACE_PYTHON
+# (not bare shebang) so that any future `from mempalace …` import in
+# apply.py resolves to the same interpreter as curate.py.
+echo "$CURATE_OUT" | "$MEMPALACE_PYTHON" "$(dirname "$0")/apply.py"

--- a/.claude/skills/harness-curator/scripts/test.sh
+++ b/.claude/skills/harness-curator/scripts/test.sh
@@ -152,5 +152,65 @@ PARKED=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "parked-singl
 [ -z "$PARKED" ] || { echo "FAIL: parked-singleton should be parked, not in clusters" >&2; exit 1; }
 echo "  PASS parked-singleton excluded from output"
 
+# --- apply.py orchestration (--dry-run-apply) ----------------------------
+# Pipe the curator JSON through apply.py --dry-run-apply. Each cluster
+# round-trips as one JSON-array line representing the `gh issue create`
+# argv that would have been invoked. The flag exists so we never need to
+# stub `gh` to assert orchestration shape.
+APPLY="$SKILL_DIR/scripts/apply.py"
+[ -f "$APPLY" ] || { echo "FAIL: apply.py missing: $APPLY" >&2; exit 1; }
+
+set +e
+APPLY_OUT=$(printf '%s\n' "$OUT" | python3 "$APPLY" --dry-run-apply)
+APPLY_RC=$?
+set -e
+assert "apply --dry-run-apply exit code" "0" "$APPLY_RC"
+
+# Two qualified clusters → exactly two argv lines, no spurious output.
+APPLY_LINES=$(printf '%s\n' "$APPLY_OUT" | grep -c '^\[')
+assert "apply --dry-run-apply emits one argv line per cluster" "2" "$APPLY_LINES"
+
+# Helper jq filter: collect all `--label <value>` pairs as a list, in order.
+LABELS_FILTER='[. as $a | range(length) | select($a[.] == "--label") | $a[.+1]]'
+
+# yq-merge argv shape: gh issue create against the stripped repo slug,
+# carrying the cluster title and the full three-label tuple in order.
+YQ_TITLE=$(echo "$YQ" | jq -r '.title')
+YQ_ARGV=$(printf '%s\n' "$APPLY_OUT" | jq -c --arg t "$YQ_TITLE" \
+  'select(type == "array" and (index($t) != null))')
+[ -n "$YQ_ARGV" ] || { echo "FAIL: yq-merge argv line not found in apply output" >&2; exit 1; }
+assert "yq-merge argv head" '["gh","issue","create"]' \
+  "$(echo "$YQ_ARGV" | jq -c '.[0:3]')"
+assert "yq-merge argv --repo (prefix stripped)" "hcross/crewrig" \
+  "$(echo "$YQ_ARGV" | jq -r '.[(index("--repo"))+1]')"
+assert "yq-merge argv labels" '["harness-feedback","room:prompt","severity:med"]' \
+  "$(echo "$YQ_ARGV" | jq -c "$LABELS_FILTER")"
+
+# gh-body-truncation argv: same structural checks, severity:high labels.
+HIGH_TITLE=$(echo "$HIGH" | jq -r '.title')
+HIGH_ARGV=$(printf '%s\n' "$APPLY_OUT" | jq -c --arg t "$HIGH_TITLE" \
+  'select(type == "array" and (index($t) != null))')
+[ -n "$HIGH_ARGV" ] || { echo "FAIL: gh-body-truncation argv line not found" >&2; exit 1; }
+assert "gh-body-truncation argv head" '["gh","issue","create"]' \
+  "$(echo "$HIGH_ARGV" | jq -c '.[0:3]')"
+assert "gh-body-truncation argv --repo (prefix stripped)" "hcross/crewrig" \
+  "$(echo "$HIGH_ARGV" | jq -r '.[(index("--repo"))+1]')"
+assert "gh-body-truncation argv labels" '["harness-feedback","room:tool","severity:high"]' \
+  "$(echo "$HIGH_ARGV" | jq -c "$LABELS_FILTER")"
+
+# No-clusters branch: empty .clusters yields the friendly notice, exit 0.
+EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[]}'
+set +e
+EMPTY_OUT=$(printf '%s\n' "$EMPTY_JSON" | python3 "$APPLY" --dry-run-apply)
+EMPTY_RC=$?
+set -e
+assert "apply --dry-run-apply empty clusters exit code" "0" "$EMPTY_RC"
+echo "$EMPTY_OUT" | grep -q "No clusters above threshold; no issues to open." || {
+  echo "FAIL: empty-clusters notice missing" >&2
+  echo "$EMPTY_OUT" >&2
+  exit 1
+}
+echo "  PASS apply --dry-run-apply emits no-clusters notice"
+
 echo ""
 echo "OK: harness-curate smoke test passed."

--- a/.gemini/skills/harness-curator/scripts/apply.py
+++ b/.gemini/skills/harness-curator/scripts/apply.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""harness_curate — Apply step.
+
+Reads the cluster JSON emitted by ``curate.py`` on stdin and either opens
+one GitHub issue per cluster via ``gh issue create`` (default) or, with
+``--dry-run-apply``, prints the resolved ``gh`` argv as one JSON line per
+cluster without running anything.
+
+The script is invoked by ``curate.sh`` through ``$MEMPALACE_PYTHON``
+rather than via shebang exec, so that any future ``from mempalace …``
+import resolves against the same interpreter that ``curate.py`` uses.
+The ``#!/usr/bin/env python3`` shebang above is kept so a human can still
+run the script standalone for debugging.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def _build_cmd(cluster: dict) -> list[str]:
+    target = cluster["target_repo"]
+    title = cluster["title"]
+    body = cluster["body"]
+    labels = cluster.get("labels", ["harness-feedback"])
+    cmd = [
+        "gh", "issue", "create",
+        "--repo", target.replace("https://github.com/", ""),
+        "--title", title,
+        "--body", body,
+    ]
+    for lbl in labels:
+        cmd.extend(["--label", lbl])
+    return cmd
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run-apply",
+        action="store_true",
+        help="Print the resolved gh argv per cluster as JSON lines and exit 0.",
+    )
+    args = parser.parse_args()
+
+    data = json.load(sys.stdin)
+    clusters = data.get("clusters", [])
+    if not clusters:
+        print("No clusters above threshold; no issues to open.")
+        return 0
+
+    if args.dry_run_apply:
+        for c in clusters:
+            print(json.dumps(_build_cmd(c)))
+        return 0
+
+    opened = []
+    failures = []
+    for c in clusters:
+        target = c["target_repo"]
+        title = c["title"]
+        print(f"--- Opening issue on {target}: {title}")
+        cmd = _build_cmd(c)
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            opened.append({"cluster": c["cluster_key"], "url": result.stdout.strip()})
+        except subprocess.CalledProcessError as e:
+            failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
+
+    print()
+    print(f"Opened: {len(opened)} issue(s)")
+    for o in opened:
+        print(f"  - {o['cluster']}: {o['url']}")
+    if failures:
+        print(f"Failures: {len(failures)}", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f['cluster']}: {f['error']}", file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.gemini/skills/harness-curator/scripts/curate.sh
+++ b/.gemini/skills/harness-curator/scripts/curate.sh
@@ -98,9 +98,11 @@ command -v "$MEMPALACE_PYTHON" >/dev/null 2>&1 || {
 }
 
 # --- Run the curator ---
-# Read stdin into a tempfile if applicable so the python heredoc can re-open
-# it; passing stdin straight to the heredoc works on bash but fails when the
-# script is sourced or run under unusual launchers.
+# Read stdin into a tempfile if applicable so curate.py can re-open it;
+# passing stdin straight through works on bash but fails when the script
+# is sourced or run under unusual launchers. The tempfile + trap stays
+# here (not in apply.py) because the stdin payload feeds curate.py, not
+# apply.py, and the cleanup must outlive both python subprocesses.
 STDIN_FILE=""
 if [ "$FROM_STDIN" = true ]; then
   STDIN_FILE=$(mktemp -t crewrig-curate.XXXXXX)
@@ -129,43 +131,7 @@ command -v gh >/dev/null 2>&1 || {
   exit 3
 }
 
-# Parse JSON and open one issue per cluster.
-echo "$CURATE_OUT" | "$MEMPALACE_PYTHON" -c '
-import json, os, subprocess, sys
-
-data = json.load(sys.stdin)
-clusters = data.get("clusters", [])
-if not clusters:
-    print("No clusters above threshold; no issues to open.")
-    sys.exit(0)
-
-opened = []
-failures = []
-for c in clusters:
-    target = c["target_repo"]
-    title = c["title"]
-    body = c["body"]
-    labels = c.get("labels", ["harness-feedback"])
-    print(f"--- Opening issue on {target}: {title}")
-    cmd = ["gh", "issue", "create",
-           "--repo", target.replace("https://github.com/", ""),
-           "--title", title,
-           "--body", body]
-    for lbl in labels:
-        cmd.extend(["--label", lbl])
-    try:
-        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-        opened.append({"cluster": c["cluster_key"], "url": result.stdout.strip()})
-    except subprocess.CalledProcessError as e:
-        failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
-
-print()
-print(f"Opened: {len(opened)} issue(s)")
-for o in opened:
-    print(f"  - {o[\"cluster\"]}: {o[\"url\"]}")
-if failures:
-    print(f"Failures: {len(failures)}", file=sys.stderr)
-    for f in failures:
-        print(f"  - {f[\"cluster\"]}: {f[\"error\"]}", file=sys.stderr)
-    sys.exit(4)
-'
+# Parse JSON and open one issue per cluster. Invoke via $MEMPALACE_PYTHON
+# (not bare shebang) so that any future `from mempalace …` import in
+# apply.py resolves to the same interpreter as curate.py.
+echo "$CURATE_OUT" | "$MEMPALACE_PYTHON" "$(dirname "$0")/apply.py"

--- a/.gemini/skills/harness-curator/scripts/test.sh
+++ b/.gemini/skills/harness-curator/scripts/test.sh
@@ -152,5 +152,65 @@ PARKED=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "parked-singl
 [ -z "$PARKED" ] || { echo "FAIL: parked-singleton should be parked, not in clusters" >&2; exit 1; }
 echo "  PASS parked-singleton excluded from output"
 
+# --- apply.py orchestration (--dry-run-apply) ----------------------------
+# Pipe the curator JSON through apply.py --dry-run-apply. Each cluster
+# round-trips as one JSON-array line representing the `gh issue create`
+# argv that would have been invoked. The flag exists so we never need to
+# stub `gh` to assert orchestration shape.
+APPLY="$SKILL_DIR/scripts/apply.py"
+[ -f "$APPLY" ] || { echo "FAIL: apply.py missing: $APPLY" >&2; exit 1; }
+
+set +e
+APPLY_OUT=$(printf '%s\n' "$OUT" | python3 "$APPLY" --dry-run-apply)
+APPLY_RC=$?
+set -e
+assert "apply --dry-run-apply exit code" "0" "$APPLY_RC"
+
+# Two qualified clusters → exactly two argv lines, no spurious output.
+APPLY_LINES=$(printf '%s\n' "$APPLY_OUT" | grep -c '^\[')
+assert "apply --dry-run-apply emits one argv line per cluster" "2" "$APPLY_LINES"
+
+# Helper jq filter: collect all `--label <value>` pairs as a list, in order.
+LABELS_FILTER='[. as $a | range(length) | select($a[.] == "--label") | $a[.+1]]'
+
+# yq-merge argv shape: gh issue create against the stripped repo slug,
+# carrying the cluster title and the full three-label tuple in order.
+YQ_TITLE=$(echo "$YQ" | jq -r '.title')
+YQ_ARGV=$(printf '%s\n' "$APPLY_OUT" | jq -c --arg t "$YQ_TITLE" \
+  'select(type == "array" and (index($t) != null))')
+[ -n "$YQ_ARGV" ] || { echo "FAIL: yq-merge argv line not found in apply output" >&2; exit 1; }
+assert "yq-merge argv head" '["gh","issue","create"]' \
+  "$(echo "$YQ_ARGV" | jq -c '.[0:3]')"
+assert "yq-merge argv --repo (prefix stripped)" "hcross/crewrig" \
+  "$(echo "$YQ_ARGV" | jq -r '.[(index("--repo"))+1]')"
+assert "yq-merge argv labels" '["harness-feedback","room:prompt","severity:med"]' \
+  "$(echo "$YQ_ARGV" | jq -c "$LABELS_FILTER")"
+
+# gh-body-truncation argv: same structural checks, severity:high labels.
+HIGH_TITLE=$(echo "$HIGH" | jq -r '.title')
+HIGH_ARGV=$(printf '%s\n' "$APPLY_OUT" | jq -c --arg t "$HIGH_TITLE" \
+  'select(type == "array" and (index($t) != null))')
+[ -n "$HIGH_ARGV" ] || { echo "FAIL: gh-body-truncation argv line not found" >&2; exit 1; }
+assert "gh-body-truncation argv head" '["gh","issue","create"]' \
+  "$(echo "$HIGH_ARGV" | jq -c '.[0:3]')"
+assert "gh-body-truncation argv --repo (prefix stripped)" "hcross/crewrig" \
+  "$(echo "$HIGH_ARGV" | jq -r '.[(index("--repo"))+1]')"
+assert "gh-body-truncation argv labels" '["harness-feedback","room:tool","severity:high"]' \
+  "$(echo "$HIGH_ARGV" | jq -c "$LABELS_FILTER")"
+
+# No-clusters branch: empty .clusters yields the friendly notice, exit 0.
+EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[]}'
+set +e
+EMPTY_OUT=$(printf '%s\n' "$EMPTY_JSON" | python3 "$APPLY" --dry-run-apply)
+EMPTY_RC=$?
+set -e
+assert "apply --dry-run-apply empty clusters exit code" "0" "$EMPTY_RC"
+echo "$EMPTY_OUT" | grep -q "No clusters above threshold; no issues to open." || {
+  echo "FAIL: empty-clusters notice missing" >&2
+  echo "$EMPTY_OUT" >&2
+  exit 1
+}
+echo "  PASS apply --dry-run-apply emits no-clusters notice"
+
 echo ""
 echo "OK: harness-curate smoke test passed."

--- a/community-config/skills/harness-curator/scripts/apply.py
+++ b/community-config/skills/harness-curator/scripts/apply.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""harness_curate — Apply step.
+
+Reads the cluster JSON emitted by ``curate.py`` on stdin and either opens
+one GitHub issue per cluster via ``gh issue create`` (default) or, with
+``--dry-run-apply``, prints the resolved ``gh`` argv as one JSON line per
+cluster without running anything.
+
+The script is invoked by ``curate.sh`` through ``$MEMPALACE_PYTHON``
+rather than via shebang exec, so that any future ``from mempalace …``
+import resolves against the same interpreter that ``curate.py`` uses.
+The ``#!/usr/bin/env python3`` shebang above is kept so a human can still
+run the script standalone for debugging.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def _build_cmd(cluster: dict) -> list[str]:
+    target = cluster["target_repo"]
+    title = cluster["title"]
+    body = cluster["body"]
+    labels = cluster.get("labels", ["harness-feedback"])
+    cmd = [
+        "gh", "issue", "create",
+        "--repo", target.replace("https://github.com/", ""),
+        "--title", title,
+        "--body", body,
+    ]
+    for lbl in labels:
+        cmd.extend(["--label", lbl])
+    return cmd
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run-apply",
+        action="store_true",
+        help="Print the resolved gh argv per cluster as JSON lines and exit 0.",
+    )
+    args = parser.parse_args()
+
+    data = json.load(sys.stdin)
+    clusters = data.get("clusters", [])
+    if not clusters:
+        print("No clusters above threshold; no issues to open.")
+        return 0
+
+    if args.dry_run_apply:
+        for c in clusters:
+            print(json.dumps(_build_cmd(c)))
+        return 0
+
+    opened = []
+    failures = []
+    for c in clusters:
+        target = c["target_repo"]
+        title = c["title"]
+        print(f"--- Opening issue on {target}: {title}")
+        cmd = _build_cmd(c)
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            opened.append({"cluster": c["cluster_key"], "url": result.stdout.strip()})
+        except subprocess.CalledProcessError as e:
+            failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
+
+    print()
+    print(f"Opened: {len(opened)} issue(s)")
+    for o in opened:
+        print(f"  - {o['cluster']}: {o['url']}")
+    if failures:
+        print(f"Failures: {len(failures)}", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f['cluster']}: {f['error']}", file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/community-config/skills/harness-curator/scripts/curate.sh
+++ b/community-config/skills/harness-curator/scripts/curate.sh
@@ -98,9 +98,11 @@ command -v "$MEMPALACE_PYTHON" >/dev/null 2>&1 || {
 }
 
 # --- Run the curator ---
-# Read stdin into a tempfile if applicable so the python heredoc can re-open
-# it; passing stdin straight to the heredoc works on bash but fails when the
-# script is sourced or run under unusual launchers.
+# Read stdin into a tempfile if applicable so curate.py can re-open it;
+# passing stdin straight through works on bash but fails when the script
+# is sourced or run under unusual launchers. The tempfile + trap stays
+# here (not in apply.py) because the stdin payload feeds curate.py, not
+# apply.py, and the cleanup must outlive both python subprocesses.
 STDIN_FILE=""
 if [ "$FROM_STDIN" = true ]; then
   STDIN_FILE=$(mktemp -t crewrig-curate.XXXXXX)
@@ -129,43 +131,7 @@ command -v gh >/dev/null 2>&1 || {
   exit 3
 }
 
-# Parse JSON and open one issue per cluster.
-echo "$CURATE_OUT" | "$MEMPALACE_PYTHON" -c '
-import json, os, subprocess, sys
-
-data = json.load(sys.stdin)
-clusters = data.get("clusters", [])
-if not clusters:
-    print("No clusters above threshold; no issues to open.")
-    sys.exit(0)
-
-opened = []
-failures = []
-for c in clusters:
-    target = c["target_repo"]
-    title = c["title"]
-    body = c["body"]
-    labels = c.get("labels", ["harness-feedback"])
-    print(f"--- Opening issue on {target}: {title}")
-    cmd = ["gh", "issue", "create",
-           "--repo", target.replace("https://github.com/", ""),
-           "--title", title,
-           "--body", body]
-    for lbl in labels:
-        cmd.extend(["--label", lbl])
-    try:
-        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-        opened.append({"cluster": c["cluster_key"], "url": result.stdout.strip()})
-    except subprocess.CalledProcessError as e:
-        failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
-
-print()
-print(f"Opened: {len(opened)} issue(s)")
-for o in opened:
-    print(f"  - {o[\"cluster\"]}: {o[\"url\"]}")
-if failures:
-    print(f"Failures: {len(failures)}", file=sys.stderr)
-    for f in failures:
-        print(f"  - {f[\"cluster\"]}: {f[\"error\"]}", file=sys.stderr)
-    sys.exit(4)
-'
+# Parse JSON and open one issue per cluster. Invoke via $MEMPALACE_PYTHON
+# (not bare shebang) so that any future `from mempalace …` import in
+# apply.py resolves to the same interpreter as curate.py.
+echo "$CURATE_OUT" | "$MEMPALACE_PYTHON" "$(dirname "$0")/apply.py"

--- a/community-config/skills/harness-curator/scripts/test.sh
+++ b/community-config/skills/harness-curator/scripts/test.sh
@@ -152,5 +152,65 @@ PARKED=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "parked-singl
 [ -z "$PARKED" ] || { echo "FAIL: parked-singleton should be parked, not in clusters" >&2; exit 1; }
 echo "  PASS parked-singleton excluded from output"
 
+# --- apply.py orchestration (--dry-run-apply) ----------------------------
+# Pipe the curator JSON through apply.py --dry-run-apply. Each cluster
+# round-trips as one JSON-array line representing the `gh issue create`
+# argv that would have been invoked. The flag exists so we never need to
+# stub `gh` to assert orchestration shape.
+APPLY="$SKILL_DIR/scripts/apply.py"
+[ -f "$APPLY" ] || { echo "FAIL: apply.py missing: $APPLY" >&2; exit 1; }
+
+set +e
+APPLY_OUT=$(printf '%s\n' "$OUT" | python3 "$APPLY" --dry-run-apply)
+APPLY_RC=$?
+set -e
+assert "apply --dry-run-apply exit code" "0" "$APPLY_RC"
+
+# Two qualified clusters → exactly two argv lines, no spurious output.
+APPLY_LINES=$(printf '%s\n' "$APPLY_OUT" | grep -c '^\[')
+assert "apply --dry-run-apply emits one argv line per cluster" "2" "$APPLY_LINES"
+
+# Helper jq filter: collect all `--label <value>` pairs as a list, in order.
+LABELS_FILTER='[. as $a | range(length) | select($a[.] == "--label") | $a[.+1]]'
+
+# yq-merge argv shape: gh issue create against the stripped repo slug,
+# carrying the cluster title and the full three-label tuple in order.
+YQ_TITLE=$(echo "$YQ" | jq -r '.title')
+YQ_ARGV=$(printf '%s\n' "$APPLY_OUT" | jq -c --arg t "$YQ_TITLE" \
+  'select(type == "array" and (index($t) != null))')
+[ -n "$YQ_ARGV" ] || { echo "FAIL: yq-merge argv line not found in apply output" >&2; exit 1; }
+assert "yq-merge argv head" '["gh","issue","create"]' \
+  "$(echo "$YQ_ARGV" | jq -c '.[0:3]')"
+assert "yq-merge argv --repo (prefix stripped)" "hcross/crewrig" \
+  "$(echo "$YQ_ARGV" | jq -r '.[(index("--repo"))+1]')"
+assert "yq-merge argv labels" '["harness-feedback","room:prompt","severity:med"]' \
+  "$(echo "$YQ_ARGV" | jq -c "$LABELS_FILTER")"
+
+# gh-body-truncation argv: same structural checks, severity:high labels.
+HIGH_TITLE=$(echo "$HIGH" | jq -r '.title')
+HIGH_ARGV=$(printf '%s\n' "$APPLY_OUT" | jq -c --arg t "$HIGH_TITLE" \
+  'select(type == "array" and (index($t) != null))')
+[ -n "$HIGH_ARGV" ] || { echo "FAIL: gh-body-truncation argv line not found" >&2; exit 1; }
+assert "gh-body-truncation argv head" '["gh","issue","create"]' \
+  "$(echo "$HIGH_ARGV" | jq -c '.[0:3]')"
+assert "gh-body-truncation argv --repo (prefix stripped)" "hcross/crewrig" \
+  "$(echo "$HIGH_ARGV" | jq -r '.[(index("--repo"))+1]')"
+assert "gh-body-truncation argv labels" '["harness-feedback","room:tool","severity:high"]' \
+  "$(echo "$HIGH_ARGV" | jq -c "$LABELS_FILTER")"
+
+# No-clusters branch: empty .clusters yields the friendly notice, exit 0.
+EMPTY_JSON='{"stats":{"total_drawers":0,"valid_frictions":0,"skipped_malformed":0,"clusters_formed":0,"clusters_above_threshold":0,"clusters_parked":0,"routing_failures":0},"clusters":[]}'
+set +e
+EMPTY_OUT=$(printf '%s\n' "$EMPTY_JSON" | python3 "$APPLY" --dry-run-apply)
+EMPTY_RC=$?
+set -e
+assert "apply --dry-run-apply empty clusters exit code" "0" "$EMPTY_RC"
+echo "$EMPTY_OUT" | grep -q "No clusters above threshold; no issues to open." || {
+  echo "FAIL: empty-clusters notice missing" >&2
+  echo "$EMPTY_OUT" >&2
+  exit 1
+}
+echo "  PASS apply --dry-run-apply emits no-clusters notice"
+
 echo ""
 echo "OK: harness-curate smoke test passed."


### PR DESCRIPTION
The Curator's `--apply` step was a ~40-line Python heredoc inside `curate.sh`; this PR lifts it into a standalone `apply.py` so it is highlightable, testable, and editable without quoting-by-shell. The change is a pure refactor — no behavioural delta on the happy path, but `--dry-run-apply` is now a first-class flag the test harness exercises end-to-end.

## How to read this PR?

Read in this order:

1. `community-config/skills/harness-curator/scripts/apply.py` — the new file. Note the `--dry-run-apply` branch in `main()` and the `_build_cmd` helper that keeps the execute path and the dry-run path from drifting.
2. `community-config/skills/harness-curator/scripts/curate.sh` — the diff is mostly deletion (heredoc → one-line pipe). Confirm the `command -v gh` pre-check at line 129 still gates the call, and the `STDIN_FILE` `trap` is preserved.
3. `community-config/skills/harness-curator/scripts/test.sh` — the 10 new assertions are appended after the `parked-singleton` block, before the trailing `echo "OK: …"`. The existing 21 are untouched.
4. The regenerated bundles under `.gemini/skills/harness-curator/scripts/` and `.claude/skills/harness-curator/scripts/` are the build output of `scripts/build-components.sh` on the new sources — reviewable as a sanity check, not as load-bearing changes.

The load-bearing design decision is to keep orchestration as a *separate script* rather than fold it into a `curate.py --apply` mode. Trade-off accepted: contributors must remember the apply step now lives in `apply.py`. Upside: each script has a single responsibility, and `apply.py` is invokable in isolation with stubbed input.

## How to test this PR?

```bash
bash community-config/skills/harness-curator/scripts/test.sh
bash scripts/check-skill-versions.sh
bash scripts/build-components.sh --target all --check
```

Expected:

- `test.sh` prints 31 `PASS …` lines (was 21 before this PR) and ends with `OK: harness-curate smoke test passed.`.
- `check-skill-versions.sh` exits 0 with `OK: no skill/agent sources changed vs origin/release/crew-v0` — no `SKILL.md`/`AGENT.md` source changed, so the SemVer guard is dormant by design.
- `build-components.sh --check` exits 0 with `OK: All generated files match source.` — bundles regenerated in commit `a0f87f8`.

## Detailed description (for agents)

### Changes

- **`community-config/skills/harness-curator/scripts/apply.py`** (new, 92 lines, executable, shebang `#!/usr/bin/env python3`). Reads cluster JSON from stdin, iterates over `clusters[]`, calls `gh issue create` per cluster. New flag `--dry-run-apply`: same iteration, but prints each cluster's resolved argv as one JSON-array line to stdout instead of forking `gh`. Exit codes match the prior heredoc: 0 on full success (including the no-clusters branch which prints `No clusters above threshold; no issues to open.`), 4 on partial subprocess failure.
- **`community-config/skills/harness-curator/scripts/curate.sh`** (−35 net lines). The Python heredoc is replaced by `echo "$CURATE_OUT" | "$MEMPALACE_PYTHON" "$(dirname \"$0\")/apply.py"`. Retained in bash: `set -euo pipefail`, the `command -v gh` pre-check at line 129, and the `STDIN_FILE` `trap` cleanup. Two new one-line comments document why the trap stays in bash and why the python invocation goes through `$MEMPALACE_PYTHON` rather than a bare shebang (silent divergence risk if a future import lands in `apply.py` while a pipx venv is active).
- **`community-config/skills/harness-curator/scripts/test.sh`** (+60 lines). Ten new assertions, all driving `apply.py --dry-run-apply`:
  1. `apply --dry-run-apply exit code` — rc=0.
  2. `apply --dry-run-apply emits one argv line per cluster` — exactly 2 lines for the fixture.
  3. `yq-merge argv head` — argv starts with `["gh","issue","create"]`.
  4. `yq-merge argv --repo (prefix stripped)` — `hcross/crewrig`, no `https://github.com/` leak.
  5. `yq-merge argv labels` — `["harness-feedback","room:prompt","severity:med"]` in order.
  6. `gh-body-truncation argv head` — same head shape.
  7. `gh-body-truncation argv --repo (prefix stripped)` — `hcross/crewrig`.
  8. `gh-body-truncation argv labels` — `["harness-feedback","room:tool","severity:high"]` in order.
  9. `apply --dry-run-apply empty clusters exit code` — rc=0 on a synthesised empty-clusters JSON.
  10. `apply --dry-run-apply emits no-clusters notice` — stdout contains `No clusters above threshold; no issues to open.`.
- **`.gemini/skills/harness-curator/scripts/`** and **`.claude/skills/harness-curator/scripts/`** (bundle regeneration, commit `a0f87f8`). The `build-components.sh` bundler copies `community-config/skills/<name>/scripts/` verbatim into both harness layouts, so source changes propagate as bundle changes. The first push of this branch shipped only the source change, and the `check-components` CI job failed on drift. Fixed by running `bash scripts/build-components.sh` and committing the result.

### Considered & dismissed

**Concern raised during tester run**: evaluated in isolation, `apply.py` would `FileNotFoundError` on a missing `gh` binary — a regression vs the pre-refactor behaviour where `curate.sh` exited cleanly with code 3.

**Verdict**: false positive. `curate.sh:129` retains the `command -v gh >/dev/null 2>&1 || { …; exit 3; }` pre-check, and the pipe to `apply.py` at line 137 only runs once that check passes. The Curator's only public entry point is `curate.sh`; `apply.py` is an internal helper. Documenting the analysis here so a future reviewer or auditor does not re-open it as a deferred risk.

### Provenance trail

- PR #47, review remark #3 — first sighting of the heredoc as friction.
- PR #56, review remark #1 — re-surfaced during the harness-curator self-containment refactor.
- Issue #57 — the ticket this PR closes (also its own logbook).

### Why a separate `apply.py` rather than `curate.py --apply`

A single-binary `curate.py` with `--apply` was considered (architect agent design pass). Rejected because:

- `curate.py` is pure: read-only against MemPalace, JSON-emitting, no side effects. `apply.py` is impure: subprocess-driven, gh-side-effecting. Keeping them in separate files preserves that disjunction.
- The bash wrapper already uses the `echo … | python …` Unix shape. A `curate.py --apply` would have forced a mode switch at the top of `main()` and entangled env-var parsing (`FRICTION_WING`, `THRESHOLD`, `FROM_STDIN_FILE`) with a code path that uses none of them.

### SemVer guard

No `community-config/skills/*/SKILL.md` or `community-config/agents/*/AGENT.md` source changed in this diff. The guard at `scripts/check-skill-versions.sh` stays dormant; no `provenance.version` bump is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)