### PR TITLE
✨ Add grounding discipline rail to pr-logbook skill (#61)

### DIFF
--- a/.claude/agents/pr-logbook/AGENT.md
+++ b/.claude/agents/pr-logbook/AGENT.md
@@ -4,7 +4,7 @@ description: "Generic PR and logbook composer agent. Drafts titles, bodies, test
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 
@@ -32,6 +32,14 @@ too.
 When the project squash-merges, you treat the squash commit message as
 the document that survives in `git log` forever, and compose it
 deliberately rather than pasting the PR description.
+
+You ground every technical claim. File counts, line counts, assertion
+lists, pass-count deltas, exit codes, and build-system invariants in your
+PR bodies and logbook entries must trace to a file path, command output,
+or sentence from your brief. If you cannot cite, you write "see diff" or
+omit. You re-read your draft once before returning and strip anything
+that fails the trace test. See `community-config/skills/pr-logbook/SKILL.md`
+→ *Grounding discipline* for the contract.
 
 When a recognition signal fires (see `config/TOOLS.md` →
 *Friction Reporting → Recognition signals*), follow the procedure in

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.2"
+  version: "1.0.3"
 ---
 
 
@@ -130,6 +130,28 @@ SemVer applies:
 A "version-only bump" PR is not a thing — the version bump always
 accompanies the content edit. See `community-config/FORMAT.md` →
 *Version semantics* for the contract.
+
+## Grounding discipline
+
+PR bodies, logbook entries, and squash commit messages compose under
+narrative pressure — the temptation is to produce a fluent paragraph that
+*sounds* like a faithful summary. Plausible-sounding detail is the failure
+mode, not vague writing.
+
+**Hard rule.** Every technical claim MUST cite a verifiable source — a
+file path with line range, a command output excerpt, or a sentence from
+the input brief. This applies to file counts, line counts, assertion
+lists, pass-count deltas, exit codes, CI step names, and build-system
+invariants (e.g. "content-addressed", "drift-free", "idempotent"). If you
+cannot cite, write "see diff" or omit the claim. Do not estimate, round,
+or generalise.
+
+**Self-check before returning.** Re-read the draft once. Mark every
+number, list-count, named invariant, and concrete technical assertion.
+For each mark, ask: does this trace to a file path, a command output, or
+a sentence in my brief? If no, delete it or replace it with "see diff".
+The self-check is cheap; a fabricated claim that reaches a reviewer or CI
+is not.
 
 ## Output expectations
 

--- a/.gemini/agents/pr-logbook.md
+++ b/.gemini/agents/pr-logbook.md
@@ -4,7 +4,7 @@ description: "Generic PR and logbook composer agent. Drafts titles, bodies, test
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 
@@ -32,6 +32,14 @@ too.
 When the project squash-merges, you treat the squash commit message as
 the document that survives in `git log` forever, and compose it
 deliberately rather than pasting the PR description.
+
+You ground every technical claim. File counts, line counts, assertion
+lists, pass-count deltas, exit codes, and build-system invariants in your
+PR bodies and logbook entries must trace to a file path, command output,
+or sentence from your brief. If you cannot cite, you write "see diff" or
+omit. You re-read your draft once before returning and strip anything
+that fails the trace test. See `community-config/skills/pr-logbook/SKILL.md`
+→ *Grounding discipline* for the contract.
 
 When a recognition signal fires (see `config/TOOLS.md` →
 *Friction Reporting → Recognition signals*), follow the procedure in

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -4,7 +4,7 @@ description: "Pull request and logbook composer. Activate when opening a PR, upd
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.2"
+  version: "1.0.3"
 ---
 
 
@@ -126,6 +126,28 @@ SemVer applies:
 A "version-only bump" PR is not a thing — the version bump always
 accompanies the content edit. See `community-config/FORMAT.md` →
 *Version semantics* for the contract.
+
+## Grounding discipline
+
+PR bodies, logbook entries, and squash commit messages compose under
+narrative pressure — the temptation is to produce a fluent paragraph that
+*sounds* like a faithful summary. Plausible-sounding detail is the failure
+mode, not vague writing.
+
+**Hard rule.** Every technical claim MUST cite a verifiable source — a
+file path with line range, a command output excerpt, or a sentence from
+the input brief. This applies to file counts, line counts, assertion
+lists, pass-count deltas, exit codes, CI step names, and build-system
+invariants (e.g. "content-addressed", "drift-free", "idempotent"). If you
+cannot cite, write "see diff" or omit the claim. Do not estimate, round,
+or generalise.
+
+**Self-check before returning.** Re-read the draft once. Mark every
+number, list-count, named invariant, and concrete technical assertion.
+For each mark, ask: does this trace to a file path, a command output, or
+a sentence in my brief? If no, delete it or replace it with "see diff".
+The self-check is cheap; a fabricated claim that reaches a reviewer or CI
+is not.
 
 ## Output expectations
 

--- a/community-config/agents/pr-logbook/AGENT.md
+++ b/community-config/agents/pr-logbook/AGENT.md
@@ -7,7 +7,7 @@ type: agent
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # PR & Logbook Agent
@@ -34,6 +34,14 @@ too.
 When the project squash-merges, you treat the squash commit message as
 the document that survives in `git log` forever, and compose it
 deliberately rather than pasting the PR description.
+
+You ground every technical claim. File counts, line counts, assertion
+lists, pass-count deltas, exit codes, and build-system invariants in your
+PR bodies and logbook entries must trace to a file path, command output,
+or sentence from your brief. If you cannot cite, you write "see diff" or
+omit. You re-read your draft once before returning and strip anything
+that fails the trace test. See `community-config/skills/pr-logbook/SKILL.md`
+→ *Grounding discipline* for the contract.
 
 When a recognition signal fires (see `config/TOOLS.md` →
 *Friction Reporting → Recognition signals*), follow the procedure in

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -8,7 +8,7 @@ type: skill
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.2"
+  version: "1.0.3"
 claude:
   allowed-tools:
     - Read
@@ -134,6 +134,28 @@ SemVer applies:
 A "version-only bump" PR is not a thing — the version bump always
 accompanies the content edit. See `community-config/FORMAT.md` →
 *Version semantics* for the contract.
+
+## Grounding discipline
+
+PR bodies, logbook entries, and squash commit messages compose under
+narrative pressure — the temptation is to produce a fluent paragraph that
+*sounds* like a faithful summary. Plausible-sounding detail is the failure
+mode, not vague writing.
+
+**Hard rule.** Every technical claim MUST cite a verifiable source — a
+file path with line range, a command output excerpt, or a sentence from
+the input brief. This applies to file counts, line counts, assertion
+lists, pass-count deltas, exit codes, CI step names, and build-system
+invariants (e.g. "content-addressed", "drift-free", "idempotent"). If you
+cannot cite, write "see diff" or omit the claim. Do not estimate, round,
+or generalise.
+
+**Self-check before returning.** Re-read the draft once. Mark every
+number, list-count, named invariant, and concrete technical assertion.
+For each mark, ask: does this trace to a file path, a command output, or
+a sentence in my brief? If no, delete it or replace it with "see diff".
+The self-check is cheap; a fabricated claim that reaches a reviewer or CI
+is not.
 
 ## Output expectations
 


### PR DESCRIPTION
This PR lands the anti-fabrication rail inside the pr-logbook skill itself, closing the loop opened by PR #60 and validated under brief-side guard in PR #65. After merge, the rail is skill-bound: future pr-logbook sessions inherit it without needing a per-PR brief override.

## How to read this PR?

Start with `community-config/skills/pr-logbook/SKILL.md` — the new `## Grounding discipline` section (inserted before `## Output expectations`) is the substantive change. Then read `community-config/agents/pr-logbook/AGENT.md` for the matching runtime paragraph; it references the skill rather than duplicating the rule, per the convention used by sibling agents (`developer/AGENT.md:29`, `harness-curator/AGENT.md:23`). The four files under `.claude/` and `.gemini/` are mechanically regenerated bundles — skim only to confirm they mirror the sources.

## How to test this PR?

```bash
# 1. SemVer guard — both sources bumped, exit 0 expected.
bash scripts/check-skill-versions.sh

# 2. Bundle drift check — sources and generated mirrors aligned.
bash scripts/build-components.sh --target all --check
```

Then visually review the new `## Grounding discipline` section in `community-config/skills/pr-logbook/SKILL.md` and the inserted paragraph in `community-config/agents/pr-logbook/AGENT.md`.

## Detailed description (for agents)

**Source-of-truth edits.**

- `community-config/skills/pr-logbook/SKILL.md`: new `## Grounding discipline` section inserted at line 138, immediately before `## Output expectations` (now at line 160). The structural delta is `^## ` heading count 8 → 9. `provenance.version` at line 11 bumped `1.0.2` → `1.0.3` (PATCH per `scripts/check-skill-versions.sh:80-84`, category "friction-driven wording addition").
- `community-config/agents/pr-logbook/AGENT.md`: new grounding paragraph inserted at line 38, immediately before the `When a recognition signal fires` paragraph (now at line 46). Frontmatter delimiter count remains 2. `provenance.version` at line 10 bumped `1.0.0` → `1.0.1` (PATCH).

**Diff stat.** Source-only: 2 files, **32 insertions, 2 deletions**. Total commit including the 4 regenerated bundles under `.claude/` and `.gemini/`: 6 files, **96 insertions, 6 deletions**. Bundles regenerated via `bash scripts/build-components.sh --target all` and verified drift-free via `--check` (exit 0, `OK: All generated files match source.`).

**Design rationale.**

- *Section placement.* The new section sits before `## Output expectations` as a top-level section, parallel to `## Friction reporting` and `## Output expectations`. Burying it mid-composition would arrive after the agent has already committed mentally to the narrative; surfacing it as a peer section keeps it visible during the framing phase, not just the polishing phase.
- *Hard rule plus self-check.* PR #60 failed with neither. PR #65 succeeded with a brief-side version of both. The hard rule catches claims as they are written; the self-check catches what slipped through. Either alone is weaker.
- *Explicit claim enumeration.* The rule names categories explicitly — file counts, line counts, assertion lists, pass-count deltas, exit codes, CI step names, build-system invariants — rather than stating a generic "do not fabricate" principle. PR #60's bundler-semantics fabrication was in a category the agent generically "knew"; a generic principle would not have stopped it.
- *AGENT.md split.* The runtime paragraph is terse and references the skill, not a duplication of the rule. This matches the convention established in `community-config/agents/developer/AGENT.md:29` and `community-config/agents/harness-curator/AGENT.md:23`.
- *SemVer.* PATCH on both files. Trigger: friction-driven wording addition. No new contract field, no breaking change.

**Recursive context for the next agent.** This PR was composed by the pr-logbook agent itself, under a brief-side anti-fabrication rail, to land the skill-side version of that rail. Until merge, the source-of-truth was the brief; after merge, the source-of-truth is the SKILL.md. Future pr-logbook invocations inherit the rule automatically and the brief override becomes unnecessary.

**Out of scope.** The same fabrication failure mode is currently open on the architect skill as `harness-friction/prompt/architect-claims-unverified` (no issue filed yet); per architect's design note, the rail is templateable and that adaptation lands in a separate MR. A doc-writer-side adaptation was also flagged by the architect's "Anything I missed" section and is likewise deferred.

**Known limit.** The self-check is unverifiable by CI: a fabricated claim in a PR body cannot be detected mechanically — the rail relies on agent compliance. Friction-reporting (via `harness-report`) is the only second-line defence; if the next pr-logbook session fabricates, the recognition signal must fire and a fresh `harness-friction/prompt/*` tag must be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)