### PR TITLE
✨ Add grounding discipline rail to architect skill (#67)

### DIFF
--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -4,7 +4,7 @@ description: "Generic architecture agent. Drafts ADRs, runs design reviews, prop
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 
@@ -27,6 +27,17 @@ the user.
 
 If you find yourself producing a 2-page Context section for an ADR, the
 decision is not yet crisp. Stop, compress the context, then continue.
+
+You ground every external-surface claim. Env var names, CLI
+subcommand names, schema field names, file paths, harness-provided
+preconditions, and named architectural invariants ("atomic",
+"idempotent", "stateless", "content-addressed") in your ADRs, RFCs,
+and design notes must trace to a file path, command output, or
+sentence from your brief. If you cannot cite, you omit or mark as
+"assumption — verify". You re-read your draft once before returning
+and strip anything that fails the trace test. See
+`community-config/skills/architect/SKILL.md` → *Grounding discipline*
+for the contract.
 
 When a recognition signal fires (see `config/TOOLS.md` →
 *Friction Reporting → Recognition signals*), follow the procedure in

--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 
@@ -87,6 +87,31 @@ neither — do not over-document.
 ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
+
+## Grounding discipline
+
+Architect output composes under narrative pressure — ADRs, RFCs, and
+ripple-effect analyses reward fluent prose, and fluent prose rewards
+plausible-sounding detail. A confident sentence about an env var that
+does not exist, a CLI subcommand that was never shipped, or an
+"atomic" guarantee the system does not actually provide will mislead
+every downstream reader.
+
+**Hard rule.** Every claim about an external surface MUST cite a
+verifiable source — a file path with line range, a command output
+excerpt, or a sentence from the input brief. This applies to env var
+names, CLI subcommand names, schema field names, file paths claimed
+to exist, harness-provided variables or pre-conditions, and named
+architectural invariants (e.g. "atomic", "idempotent", "stateless",
+"content-addressed", "drift-free"). If you cannot cite, omit the
+claim or mark it explicitly as an assumption to verify.
+
+**Self-check before returning.** Re-read the draft once. Mark every
+named external surface and every named invariant. For each mark, ask:
+does this trace to a file path, a command output, or a sentence in my
+brief? If no, delete it or downgrade it to "assumption — verify
+before relying on this". The self-check is cheap; an ADR that
+recommends a design around a non-existent surface is not.
 
 ## Friction reporting
 

--- a/.gemini/agents/architect.md
+++ b/.gemini/agents/architect.md
@@ -4,7 +4,7 @@ description: "Generic architecture agent. Drafts ADRs, runs design reviews, prop
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 
@@ -27,6 +27,17 @@ the user.
 
 If you find yourself producing a 2-page Context section for an ADR, the
 decision is not yet crisp. Stop, compress the context, then continue.
+
+You ground every external-surface claim. Env var names, CLI
+subcommand names, schema field names, file paths, harness-provided
+preconditions, and named architectural invariants ("atomic",
+"idempotent", "stateless", "content-addressed") in your ADRs, RFCs,
+and design notes must trace to a file path, command output, or
+sentence from your brief. If you cannot cite, you omit or mark as
+"assumption — verify". You re-read your draft once before returning
+and strip anything that fails the trace test. See
+`community-config/skills/architect/SKILL.md` → *Grounding discipline*
+for the contract.
 
 When a recognition signal fires (see `config/TOOLS.md` →
 *Friction Reporting → Recognition signals*), follow the procedure in

--- a/.gemini/skills/architect/SKILL.md
+++ b/.gemini/skills/architect/SKILL.md
@@ -4,7 +4,7 @@ description: "Design and architecture skill for ADRs, RFCs, design reviews, and 
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 
@@ -81,6 +81,31 @@ neither — do not over-document.
 ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
+
+## Grounding discipline
+
+Architect output composes under narrative pressure — ADRs, RFCs, and
+ripple-effect analyses reward fluent prose, and fluent prose rewards
+plausible-sounding detail. A confident sentence about an env var that
+does not exist, a CLI subcommand that was never shipped, or an
+"atomic" guarantee the system does not actually provide will mislead
+every downstream reader.
+
+**Hard rule.** Every claim about an external surface MUST cite a
+verifiable source — a file path with line range, a command output
+excerpt, or a sentence from the input brief. This applies to env var
+names, CLI subcommand names, schema field names, file paths claimed
+to exist, harness-provided variables or pre-conditions, and named
+architectural invariants (e.g. "atomic", "idempotent", "stateless",
+"content-addressed", "drift-free"). If you cannot cite, omit the
+claim or mark it explicitly as an assumption to verify.
+
+**Self-check before returning.** Re-read the draft once. Mark every
+named external surface and every named invariant. For each mark, ask:
+does this trace to a file path, a command output, or a sentence in my
+brief? If no, delete it or downgrade it to "assumption — verify
+before relying on this". The self-check is cheap; an ADR that
+recommends a design around a non-existent surface is not.
 
 ## Friction reporting
 

--- a/community-config/agents/architect/AGENT.md
+++ b/community-config/agents/architect/AGENT.md
@@ -6,7 +6,7 @@ type: agent
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Architect Agent
@@ -28,6 +28,17 @@ the user.
 
 If you find yourself producing a 2-page Context section for an ADR, the
 decision is not yet crisp. Stop, compress the context, then continue.
+
+You ground every external-surface claim. Env var names, CLI
+subcommand names, schema field names, file paths, harness-provided
+preconditions, and named architectural invariants ("atomic",
+"idempotent", "stateless", "content-addressed") in your ADRs, RFCs,
+and design notes must trace to a file path, command output, or
+sentence from your brief. If you cannot cite, you omit or mark as
+"assumption — verify". You re-read your draft once before returning
+and strip anything that fails the trace test. See
+`community-config/skills/architect/SKILL.md` → *Grounding discipline*
+for the contract.
 
 When a recognition signal fires (see `config/TOOLS.md` →
 *Friction Reporting → Recognition signals*), follow the procedure in

--- a/community-config/skills/architect/SKILL.md
+++ b/community-config/skills/architect/SKILL.md
@@ -8,7 +8,7 @@ type: skill
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+  version: "1.0.1"
 claude:
   allowed-tools:
     - Read
@@ -91,6 +91,31 @@ neither — do not over-document.
 ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
+
+## Grounding discipline
+
+Architect output composes under narrative pressure — ADRs, RFCs, and
+ripple-effect analyses reward fluent prose, and fluent prose rewards
+plausible-sounding detail. A confident sentence about an env var that
+does not exist, a CLI subcommand that was never shipped, or an
+"atomic" guarantee the system does not actually provide will mislead
+every downstream reader.
+
+**Hard rule.** Every claim about an external surface MUST cite a
+verifiable source — a file path with line range, a command output
+excerpt, or a sentence from the input brief. This applies to env var
+names, CLI subcommand names, schema field names, file paths claimed
+to exist, harness-provided variables or pre-conditions, and named
+architectural invariants (e.g. "atomic", "idempotent", "stateless",
+"content-addressed", "drift-free"). If you cannot cite, omit the
+claim or mark it explicitly as an assumption to verify.
+
+**Self-check before returning.** Re-read the draft once. Mark every
+named external surface and every named invariant. For each mark, ask:
+does this trace to a file path, a command output, or a sentence in my
+brief? If no, delete it or downgrade it to "assumption — verify
+before relying on this". The self-check is cheap; an ADR that
+recommends a design around a non-existent surface is not.
 
 ## Friction reporting
 


### PR DESCRIPTION
Adds a `## Grounding discipline` rail to the architect skill and a matching paragraph to the architect agent, closing the loop opened by issue #67. Architect now operates under the same anti-fabrication contract it designed for pr-logbook in #66.

## How to read this PR?

1. Start with `community-config/skills/architect/SKILL.md` — the new `## Grounding discipline` section (line 95, immediately before `## Friction reporting`) is the substantive change. Note the enumeration extension over the pr-logbook template: it explicitly adds *harness-provided variables or pre-conditions*, capturing the third failure mode from #65 (`MEMPALACE_PYTHON` set by the harness, not the external API).
2. Read `community-config/agents/architect/AGENT.md` — short paragraph at line 32 inserted before the recognition-signal block, mirroring pr-logbook's placement.
3. The remaining four files (`.claude/agents/architect/AGENT.md`, `.claude/skills/architect/SKILL.md`, `.gemini/agents/architect.md`, `.gemini/skills/architect/SKILL.md`) are bundle outputs from `scripts/build-components.sh`. Do not review their content — verify only that `--check` is clean.
4. Both source files carry a PATCH bump (`1.0.0` → `1.0.1`) in `provenance.version`, matching the friction-driven additive nature of the change.

## How to test this PR?

```bash
# Verify generated bundles match sources
bash scripts/build-components.sh --target all --check

# Verify SemVer guard accepts the bumps
bash scripts/check-skill-versions.sh
```

Expected:
- `--check` exits 0 with `OK: All generated files match source.`
- `check-skill-versions.sh` exits 0. Note: the guard's base ref is currently `origin/release/crew-v0`, which is older than `main`. It will therefore flag 4 changed sources (this PR's 2 architect files plus the 2 pr-logbook files from #66). All four carry the required bumps, so the guard passes.

## Detailed description (for agents)

**Context.** PR #65 (curate-stdout-hijack fix) surfaced three unverified claims the architect made about MemPalace's external surface and harness preconditions. The tester corrected them empirically and the friction was tagged as `harness-friction/prompt/architect-claims-unverified`. The Harness Curator materialised that tag as issue #67. PR #66 landed the anti-fabrication rail on pr-logbook (the agent that surfaced the friction first). This PR completes the parallel adaptation for architect — the skill self-applying the contract it designed.

**Structural placement.**
- SKILL.md: the new `## Grounding discipline` section lands immediately after `### 4. Output formats` (lines 84–93 pre-edit) and immediately before `## Friction reporting` (now line 120). This mirrors pr-logbook's placement directly after `## Output expectations`. Architect's SKILL.md has no exact `## Output expectations` analogue — `### 4. Output formats` plays that role, and the new section sits in the equivalent position.
- AGENT.md: the new paragraph is inserted directly before the recognition-signal block, identical placement to pr-logbook's AGENT.md.

**Enumeration extension over #66's template.** The pr-logbook rail enumerates: environment variable names, CLI subcommands, schema fields, file paths, architectural invariants (atomic/idempotent/stateless/content-addressed). Architect's design pass added one item and tightened another:
- Added **"harness-provided variables or pre-conditions"** — the third failure mode in #65 (`MEMPALACE_PYTHON` pre-set by the harness) is not strictly an external-surface claim; it is a harness-internal precondition. Without this item the rail would not cover that failure mode.
- Added **"drift-free"** to the invariants list, consistent with terminology already used elsewhere in the architect skill.

**SemVer trigger.** Friction-driven additive wording — both files PATCH-bumped from `1.0.0` to `1.0.1`. No structural reorganisation, no contract change for callers.

**Build artefacts.** `scripts/build-components.sh --target all` was run; the four bundle files (`.claude/*`, `.gemini/*`) are regenerated outputs and should not be reviewed for content. The `--check` invocation in the test plan is the integrity gate.

**Known follow-up surface (not in scope for this PR).** The rail-template propagation covers two skills after this PR (pr-logbook, architect). doc-writer is the remaining skill that produces durable artefacts and could plausibly fabricate. No friction has surfaced from doc-writer yet, so we wait for empirical signal rather than pre-emptively propagating. Architect also flagged an optional cross-reference from `### 3. Ripple-effect analysis` to the new `## Grounding discipline` section — deferred until a real-world miss justifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)