### PR TITLE
🔗 Correlate drawers to issues via opened_as field (#69)

### DIFF
--- a/.claude/skills/harness-curator/assets/sample-frictions.json
+++ b/.claude/skills/harness-curator/assets/sample-frictions.json
@@ -32,5 +32,11 @@
     "room": "prompt",
     "filed_at": "2026-05-10T08:00:00.000000",
     "content": "FRICTION: Empty writer_agent — must be rejected per schema\n\nwriter_agent:\nsubcategory: should-be-rejected\ncanonical: https://github.com/hcross/crewrig\nseverity: med\nevidence:\n  - foo.md:1"
+  },
+  {
+    "drawer_id": "drw-007",
+    "room": "tool",
+    "filed_at": "2026-05-07T10:00:00.000000",
+    "content": "FRICTION: Already-correlated friction must be skipped by the curator\n\nwriter_agent: claude-code\nsubcategory: stale-resolved-fixture\ncanonical: https://github.com/hcross/crewrig\nseverity: high\nevidence:\n  - community-config/skills/harness-curator/scripts/apply.py:99\nsuggestion: Skip on truthy opened_as.\nopened_as: https://github.com/hcross/crewrig/issues/99"
   }
 ]

--- a/.claude/skills/harness-curator/scripts/apply.py
+++ b/.claude/skills/harness-curator/scripts/apply.py
@@ -15,6 +15,7 @@ run the script standalone for debugging.
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 
@@ -33,6 +34,21 @@ def _build_cmd(cluster: dict) -> list[str]:
     for lbl in labels:
         cmd.extend(["--label", lbl])
     return cmd
+
+
+def _collect_drawer_ids(cluster: dict) -> tuple[list[str], int]:
+    """Return (present_ids, missing_count). Caller emits a stderr warning
+    when missing > 0 so frictions without `_drawer_id` are surfaced rather
+    than silently dropped from the write-back set."""
+    ids: list[str] = []
+    missing = 0
+    for fr in cluster.get("frictions", []):
+        did = fr.get("_drawer_id")
+        if did:
+            ids.append(did)
+        else:
+            missing += 1
+    return ids, missing
 
 
 def main() -> int:
@@ -56,29 +72,35 @@ def main() -> int:
             # Issue #69: surface the drawers that would receive the
             # `opened_as` correlation stamp. Object shape (not array) so
             # existing argv-array assertions (`grep '^\['`) ignore it.
-            drawer_ids = [
-                fr.get("_drawer_id", "")
-                for fr in c.get("frictions", [])
-                if fr.get("_drawer_id")
-            ]
+            drawer_ids, missing = _collect_drawer_ids(c)
+            if missing:
+                print(
+                    f"  warn: cluster '{c['cluster_key']}' has {missing} "
+                    "friction(s) without _drawer_id; will not be stamped.",
+                    file=sys.stderr,
+                )
             print(json.dumps({
                 "would_update_drawers": drawer_ids,
                 "cluster_key": c["cluster_key"],
             }))
         return 0
 
-    # Lazy import: only the real --apply path needs mempalace MCP. The
-    # dry-run path above must stay import-free (curate.py owns the
-    # stdout-hijack workaround at module load — apply.py runs as a
-    # standalone process and would inherit no such protection).
+    # Real --apply path. Capture a duped fd 1 BEFORE importing
+    # mempalace.mcp_server — that import swaps sys.stdout to keep the
+    # MCP JSON-RPC channel clean (same hazard documented in
+    # config/TOOLS.md and motivating curate.py's module-top dup). Result
+    # URLs and the run summary go through _real_stdout so the caller
+    # can capture them; progress messages route to stderr explicitly.
+    _real_stdout = os.fdopen(os.dup(1), "w", encoding="utf-8", closefd=False)
     from mempalace.mcp_server import tool_get_drawer, tool_update_drawer
 
     opened = []
     failures = []
+    writeback_failures = 0
     for c in clusters:
         target = c["target_repo"]
         title = c["title"]
-        print(f"--- Opening issue on {target}: {title}")
+        print(f"--- Opening issue on {target}: {title}", file=sys.stderr)
         cmd = _build_cmd(c)
         try:
             result = subprocess.run(cmd, check=True, capture_output=True, text=True)
@@ -88,17 +110,24 @@ def main() -> int:
             # contributed to the cluster (issue #69). Re-fetch then
             # update because tool_update_drawer REPLACES content; this
             # narrows the clobber window against concurrent edits.
-            # Partial failures are logged but do NOT mark the cluster
-            # failed — the issue is already opened on GitHub.
-            for fr in c.get("frictions", []):
-                did = fr.get("_drawer_id")
-                if not did:
-                    continue
+            # Partial failures are counted and logged but do NOT mark
+            # the cluster failed — the issue is already opened on
+            # GitHub. The aggregate is surfaced in the final summary so
+            # the maintainer sees that some drawers remain unstamped.
+            drawer_ids, missing = _collect_drawer_ids(c)
+            if missing:
+                print(
+                    f"  warn: cluster '{c['cluster_key']}' has {missing} "
+                    "friction(s) without _drawer_id; will not be stamped.",
+                    file=sys.stderr,
+                )
+            for did in drawer_ids:
                 try:
                     drawer = tool_get_drawer(drawer_id=did)
                     new_content = drawer["content"].rstrip() + f"\nopened_as: {url}\n"
                     tool_update_drawer(drawer_id=did, content=new_content)
                 except Exception as wb_err:  # noqa: BLE001 — best-effort write-back
+                    writeback_failures += 1
                     print(
                         f"  warn: failed to stamp opened_as on drawer {did}: {wb_err}",
                         file=sys.stderr,
@@ -106,10 +135,17 @@ def main() -> int:
         except subprocess.CalledProcessError as e:
             failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
 
-    print()
-    print(f"Opened: {len(opened)} issue(s)")
+    print("", file=_real_stdout)
+    print(f"Opened: {len(opened)} issue(s)", file=_real_stdout)
     for o in opened:
-        print(f"  - {o['cluster']}: {o['url']}")
+        print(f"  - {o['cluster']}: {o['url']}", file=_real_stdout)
+    _real_stdout.flush()
+    if writeback_failures:
+        print(
+            f"Write-back failures: {writeback_failures} drawer(s) not stamped; "
+            "next curator run may re-open these issues.",
+            file=sys.stderr,
+        )
     if failures:
         print(f"Failures: {len(failures)}", file=sys.stderr)
         for f in failures:

--- a/.claude/skills/harness-curator/scripts/apply.py
+++ b/.claude/skills/harness-curator/scripts/apply.py
@@ -53,7 +53,25 @@ def main() -> int:
     if args.dry_run_apply:
         for c in clusters:
             print(json.dumps(_build_cmd(c)))
+            # Issue #69: surface the drawers that would receive the
+            # `opened_as` correlation stamp. Object shape (not array) so
+            # existing argv-array assertions (`grep '^\['`) ignore it.
+            drawer_ids = [
+                fr.get("_drawer_id", "")
+                for fr in c.get("frictions", [])
+                if fr.get("_drawer_id")
+            ]
+            print(json.dumps({
+                "would_update_drawers": drawer_ids,
+                "cluster_key": c["cluster_key"],
+            }))
         return 0
+
+    # Lazy import: only the real --apply path needs mempalace MCP. The
+    # dry-run path above must stay import-free (curate.py owns the
+    # stdout-hijack workaround at module load — apply.py runs as a
+    # standalone process and would inherit no such protection).
+    from mempalace.mcp_server import tool_get_drawer, tool_update_drawer
 
     opened = []
     failures = []
@@ -64,7 +82,27 @@ def main() -> int:
         cmd = _build_cmd(c)
         try:
             result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-            opened.append({"cluster": c["cluster_key"], "url": result.stdout.strip()})
+            url = result.stdout.strip()
+            opened.append({"cluster": c["cluster_key"], "url": url})
+            # Write-back: stamp `opened_as: <url>` on every drawer that
+            # contributed to the cluster (issue #69). Re-fetch then
+            # update because tool_update_drawer REPLACES content; this
+            # narrows the clobber window against concurrent edits.
+            # Partial failures are logged but do NOT mark the cluster
+            # failed — the issue is already opened on GitHub.
+            for fr in c.get("frictions", []):
+                did = fr.get("_drawer_id")
+                if not did:
+                    continue
+                try:
+                    drawer = tool_get_drawer(drawer_id=did)
+                    new_content = drawer["content"].rstrip() + f"\nopened_as: {url}\n"
+                    tool_update_drawer(drawer_id=did, content=new_content)
+                except Exception as wb_err:  # noqa: BLE001 — best-effort write-back
+                    print(
+                        f"  warn: failed to stamp opened_as on drawer {did}: {wb_err}",
+                        file=sys.stderr,
+                    )
         except subprocess.CalledProcessError as e:
             failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
 

--- a/.claude/skills/harness-curator/scripts/curate.py
+++ b/.claude/skills/harness-curator/scripts/curate.py
@@ -16,6 +16,7 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
         "total_drawers": int,
         "valid_frictions": int,
         "skipped_malformed": int,
+        "skipped_resolved": int,
         "clusters_formed": int,
         "clusters_above_threshold": int,
         "clusters_parked": int,
@@ -82,11 +83,22 @@ KV_RE = re.compile(r"^([a-z_][a-z0-9_]*):\s*(.*)$")
 LIST_RE = re.compile(r"^\s*-\s+(.+)$")
 
 
-def parse_friction(content: str) -> Optional[Dict[str, Any]]:
-    """Parse one FRICTION: payload. Return None if required fields are
-    missing — the caller treats None as "skip as malformed"."""
+def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
+    """Parse one FRICTION: payload.
+
+    Returns ``(payload, reason)``:
+      * ``(dict, "ok")``  — well-formed and still open (no ``opened_as:``).
+      * ``(None, "resolved")`` — well-formed but already correlated with a
+        GitHub issue (carries ``opened_as: <url>``). Caller skips silently
+        so the curator does not re-open issues for drawers that already
+        have one (issue #69).
+      * ``(None, "malformed")`` — missing required fields or no title.
+
+    The schema co-evolves with ``config/TOOLS.md``: ``opened_as`` is the
+    correlation field stamped on each drawer by ``apply.py`` after a
+    successful ``gh issue create``."""
     if not content:
-        return None
+        return None, "malformed"
     lines = content.splitlines()
     title = None
     body_start = 0
@@ -96,12 +108,12 @@ def parse_friction(content: str) -> Optional[Dict[str, Any]]:
             continue
         m = TITLE_RE.match(line.strip())
         if not m:
-            return None
+            return None, "malformed"
         title = m.group(1).strip()
         body_start = i + 1
         break
     if title is None:
-        return None
+        return None, "malformed"
 
     out: Dict[str, Any] = {"title": title, "evidence": []}
     in_evidence = False
@@ -129,12 +141,18 @@ def parse_friction(content: str) -> Optional[Dict[str, Any]]:
 
     # Required fields per config/TOOLS.md: writer_agent + ≥1 evidence.
     if not out.get("writer_agent"):
-        return None
+        return None, "malformed"
     if not out["evidence"]:
-        return None
+        return None, "malformed"
     # Default severity if absent.
     out.setdefault("severity", "med")
-    return out
+    # Skip drawers already correlated with an open/closed issue: the
+    # write-back stamp from apply.py (issue #69). We treat any truthy
+    # `opened_as` value as a resolved correlation — even if it's not a
+    # valid URL, the curator's job is just to avoid re-opening.
+    if out.get("opened_as"):
+        return None, "resolved"
+    return out, "ok"
 
 
 # --- Data sources ---------------------------------------------------------
@@ -205,17 +223,19 @@ def cluster_key_for(friction: Dict[str, Any], room: str) -> str:
 
 
 def cluster_frictions(
-    parsed: List[Tuple[Dict[str, Any], str, str]],
+    parsed: List[Tuple[Dict[str, Any], str, str, str]],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Group parsed frictions by cluster key. Each value entry stores the
-    friction with its room and filed_at glued in for downstream
-    traceability and for date-range computation in the MR body."""
+    friction with its room, filed_at and drawer_id glued in for downstream
+    traceability, date-range computation in the MR body, and post-create
+    write-back of the ``opened_as`` correlation field (issue #69)."""
     clusters: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
-    for friction, room, filed_at in parsed:
+    for friction, room, filed_at, drawer_id in parsed:
         key = cluster_key_for(friction, room)
         enriched = dict(friction)
         enriched["_room"] = room
         enriched["_filed_at"] = filed_at
+        enriched["_drawer_id"] = drawer_id
         clusters[key].append(enriched)
     return dict(clusters)
 
@@ -410,22 +430,27 @@ def main() -> int:
         "total_drawers": len(drawers),
         "valid_frictions": 0,
         "skipped_malformed": 0,
+        "skipped_resolved": 0,
         "clusters_formed": 0,
         "clusters_above_threshold": 0,
         "clusters_parked": 0,
         "routing_failures": 0,
     }
 
-    parsed: List[Tuple[Dict[str, Any], str, str]] = []
+    parsed: List[Tuple[Dict[str, Any], str, str, str]] = []
     for drawer in drawers:
         content = drawer.get("content", "")
         room = drawer.get("room", "")
         filed_at = drawer.get("filed_at", "")
-        friction = parse_friction(content)
+        drawer_id = drawer.get("drawer_id", "")
+        friction, reason = parse_friction(content)
         if friction is None:
-            stats["skipped_malformed"] += 1
+            if reason == "resolved":
+                stats["skipped_resolved"] += 1
+            else:
+                stats["skipped_malformed"] += 1
             continue
-        parsed.append((friction, room, filed_at))
+        parsed.append((friction, room, filed_at, drawer_id))
         stats["valid_frictions"] += 1
 
     clusters = cluster_frictions(parsed)

--- a/.claude/skills/harness-curator/scripts/test.sh
+++ b/.claude/skills/harness-curator/scripts/test.sh
@@ -61,14 +61,22 @@ assert() {
   fi
 }
 
-# 6 input drawers
-assert "stats.total_drawers"       "6" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+# 7 input drawers (drw-007 added to exercise the opened_as dedup path)
+assert "stats.total_drawers"       "7" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
 
-# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty writer_agent)
+# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty
+# writer_agent). drw-007 is well-formed but already correlated → counted
+# in skipped_resolved, NOT in skipped_malformed or valid_frictions.
 assert "stats.valid_frictions"     "4" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
 assert "stats.skipped_malformed"   "2" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
 
-# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton
+# Regression for issue #69: drw-007 carries `opened_as: <url>` and must be
+# filtered before clustering so the curator does not re-open an issue.
+assert "stats.skipped_resolved"    "1" "$(echo "$OUT" | jq -r '.stats.skipped_resolved')"
+
+# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton.
+# drw-007 is filtered upstream of clustering, so its subcategory must not
+# appear as a cluster key — see the explicit assertion further down.
 assert "stats.clusters_formed"     "3" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
 
 # Above threshold:
@@ -152,6 +160,18 @@ PARKED=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "parked-singl
 [ -z "$PARKED" ] || { echo "FAIL: parked-singleton should be parked, not in clusters" >&2; exit 1; }
 echo "  PASS parked-singleton excluded from output"
 
+# Regression for issue #69: the resolved drawer's subcategory must never
+# surface as a cluster_key. drw-007 is severity:high, so absent the
+# pre-cluster skip filter it would qualify as a high-severity singleton
+# bypass and pollute the output. Its absence proves the filter ran.
+RESOLVED_CLUSTER=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "stale-resolved-fixture")')
+[ -z "$RESOLVED_CLUSTER" ] || {
+  echo "FAIL: resolved drawer (drw-007) subcategory leaked into clusters" >&2
+  echo "$RESOLVED_CLUSTER" >&2
+  exit 1
+}
+echo "  PASS resolved-drawer subcategory absent from clusters"
+
 # --- apply.py orchestration (--dry-run-apply) ----------------------------
 # Pipe the curator JSON through apply.py --dry-run-apply. Each cluster
 # round-trips as one JSON-array line representing the `gh issue create`
@@ -167,8 +187,35 @@ set -e
 assert "apply --dry-run-apply exit code" "0" "$APPLY_RC"
 
 # Two qualified clusters → exactly two argv lines, no spurious output.
+# (apply.py now emits a sibling object line per cluster carrying the
+# would_update_drawers list — that line starts with `{`, so the `^\[`
+# filter still counts only argv arrays.)
 APPLY_LINES=$(printf '%s\n' "$APPLY_OUT" | grep -c '^\[')
 assert "apply --dry-run-apply emits one argv line per cluster" "2" "$APPLY_LINES"
+
+# Issue #69: alongside each argv array, apply.py emits a JSON object line
+# `{"would_update_drawers": [...], "cluster_key": "..."}` so the
+# orchestration shape now exposes the drawers that would receive the
+# `opened_as` write-back. Two qualified clusters → two object lines.
+APPLY_OBJECTS=$(printf '%s\n' "$APPLY_OUT" | jq -c 'select(type == "object" and (.would_update_drawers // null) != null)' 2>/dev/null || true)
+APPLY_OBJ_COUNT=$(printf '%s\n' "$APPLY_OBJECTS" | grep -c .)
+assert "apply --dry-run-apply emits one would_update_drawers object per cluster" \
+  "2" "$APPLY_OBJ_COUNT"
+
+# yq-merge object: 2 source drawers (drw-001, drw-002) propagated via _drawer_id.
+YQ_OBJ=$(printf '%s\n' "$APPLY_OBJECTS" | jq -c 'select(.cluster_key == "yq-merge")')
+[ -n "$YQ_OBJ" ] || { echo "FAIL: yq-merge would_update_drawers object missing" >&2; exit 1; }
+assert "yq-merge would_update_drawers type"   "array"   "$(echo "$YQ_OBJ" | jq -r '.would_update_drawers | type')"
+assert "yq-merge would_update_drawers length" "2"       "$(echo "$YQ_OBJ" | jq -r '.would_update_drawers | length')"
+assert "yq-merge would_update_drawers cluster_key" "yq-merge" "$(echo "$YQ_OBJ" | jq -r '.cluster_key')"
+
+# gh-body-truncation object: severity:high singleton → exactly 1 drawer (drw-003).
+HIGH_OBJ=$(printf '%s\n' "$APPLY_OBJECTS" | jq -c 'select(.cluster_key == "gh-body-truncation")')
+[ -n "$HIGH_OBJ" ] || { echo "FAIL: gh-body-truncation would_update_drawers object missing" >&2; exit 1; }
+assert "gh-body-truncation would_update_drawers cluster_key" "gh-body-truncation" \
+  "$(echo "$HIGH_OBJ" | jq -r '.cluster_key')"
+assert "gh-body-truncation would_update_drawers length" "1" \
+  "$(echo "$HIGH_OBJ" | jq -r '.would_update_drawers | length')"
 
 # Helper jq filter: collect all `--label <value>` pairs as a list, in order.
 LABELS_FILTER='[. as $a | range(length) | select($a[.] == "--label") | $a[.+1]]'
@@ -261,10 +308,17 @@ else
 
   # Seed exactly one drawer that qualifies as a singleton via the
   # severity:high bypass. Title prefix and the writer_agent / evidence
-  # keys mirror the schema in assets/sample-frictions.json.
-  "$MEMPALACE_PYTHON" - <<'PY'
+  # keys mirror the schema in assets/sample-frictions.json. The
+  # tool_add_drawer return value carries the assigned drawer_id; capture
+  # it for the round-trip assertions below (issue #69).
+  SEEDED_DRAWER_ID=$("$MEMPALACE_PYTHON" - <<'PY'
+# Mirror curate.py: dup fd 1 BEFORE importing mempalace.mcp_server, which
+# swaps sys.stdout for the JSON-RPC channel and would otherwise eat our
+# drawer_id capture.
+import os
+_real = os.fdopen(os.dup(1), "w", encoding="utf-8", closefd=False)
 from mempalace.mcp_server import tool_add_drawer
-tool_add_drawer(
+result = tool_add_drawer(
     wing="harness-friction",
     room="tool",
     content=(
@@ -277,7 +331,15 @@ tool_add_drawer(
         "  - community-config/skills/harness-curator/scripts/curate.py:60\n"
     ),
 )
+_real.write(result.get("drawer_id", "") if isinstance(result, dict) else str(result))
+_real.flush()
 PY
+)
+  [ -n "$SEEDED_DRAWER_ID" ] || {
+    echo "FAIL test_real: tool_add_drawer returned no drawer_id" >&2
+    exit 1
+  }
+  echo "  PASS test_real seeded drawer ($SEEDED_DRAWER_ID)"
 
   # Run curate.sh with NO --from-stdin so the real read_from_mempalace
   # path executes. Split stdout / stderr — mempalace chatter on stderr
@@ -322,6 +384,65 @@ PY
     "$(echo "$REAL_OUT" | jq -r '.stats.clusters_above_threshold')"
   assert "test_real.cluster_key" "real-mempalace-smoke" \
     "$(echo "$REAL_OUT" | jq -r '.clusters[0].cluster_key')"
+
+  # --- Issue #69 round-trip: _drawer_id propagation + write-back skip ----
+  # Pipe the real-MemPalace curator output through apply.py --dry-run-apply
+  # and assert that the would_update_drawers list carries the exact
+  # drawer_id returned at seed time. This proves _drawer_id propagates
+  # from tool_list_drawers → cluster JSON → apply.py argv-build.
+  set +e
+  REAL_APPLY_OUT=$(printf '%s\n' "$REAL_OUT" | python3 "$APPLY" --dry-run-apply)
+  REAL_APPLY_RC=$?
+  set -e
+  assert "test_real apply --dry-run-apply exit code" "0" "$REAL_APPLY_RC"
+
+  REAL_APPLY_OBJ=$(printf '%s\n' "$REAL_APPLY_OUT" | jq -c 'select(type == "object" and (.would_update_drawers // null) != null)')
+  [ -n "$REAL_APPLY_OBJ" ] || {
+    echo "FAIL test_real apply.would_update_drawers object missing" >&2
+    echo "$REAL_APPLY_OUT" >&2
+    exit 1
+  }
+  REAL_APPLY_IDS=$(echo "$REAL_APPLY_OBJ" | jq -c '.would_update_drawers')
+  assert "test_real would_update_drawers carries seeded drawer_id" \
+    "[\"$SEEDED_DRAWER_ID\"]" "$REAL_APPLY_IDS"
+
+  # Simulate the real --apply write-back: stamp `opened_as: <url>` on the
+  # seeded drawer the same way apply.py's real path does. The fd-dup
+  # mirrors the seed script — mempalace.mcp_server swaps sys.stdout on
+  # import.
+  "$MEMPALACE_PYTHON" - "$SEEDED_DRAWER_ID" <<'PY'
+import os, sys
+_real = os.fdopen(os.dup(1), "w", encoding="utf-8", closefd=False)
+from mempalace.mcp_server import tool_get_drawer, tool_update_drawer
+did = sys.argv[1]
+drawer = tool_get_drawer(drawer_id=did)
+new_content = drawer["content"].rstrip() + "\nopened_as: https://example.com/fake/1\n"
+tool_update_drawer(drawer_id=did, content=new_content)
+_real.write("ok")
+_real.flush()
+PY
+
+  # Re-run curate; the freshly stamped drawer must now be filtered as
+  # `resolved`, leaving zero valid frictions and zero clusters.
+  set +e
+  bash "$SCRIPT" --dry-run >"$tmpdir/out2.json" 2>"$tmpdir/err2.log"
+  REAL_RC2=$?
+  set -e
+  assert "test_real second-run exit code" "0" "$REAL_RC2"
+  REAL_OUT2=$(cat "$tmpdir/out2.json")
+  assert "test_real second-run stats.skipped_resolved" "1" \
+    "$(echo "$REAL_OUT2" | jq -r '.stats.skipped_resolved')"
+  assert "test_real second-run stats.valid_frictions" "0" \
+    "$(echo "$REAL_OUT2" | jq -r '.stats.valid_frictions')"
+  assert "test_real second-run stats.clusters_above_threshold" "0" \
+    "$(echo "$REAL_OUT2" | jq -r '.stats.clusters_above_threshold')"
+  RESOLVED_LEAK=$(echo "$REAL_OUT2" | jq -c '.clusters[] | select(.cluster_key == "real-mempalace-smoke")')
+  [ -z "$RESOLVED_LEAK" ] || {
+    echo "FAIL test_real second-run: stamped drawer leaked into clusters" >&2
+    echo "$RESOLVED_LEAK" >&2
+    exit 1
+  }
+  echo "  PASS test_real second-run: stamped drawer absent from clusters"
 fi
 
 echo ""

--- a/.gemini/skills/harness-curator/assets/sample-frictions.json
+++ b/.gemini/skills/harness-curator/assets/sample-frictions.json
@@ -32,5 +32,11 @@
     "room": "prompt",
     "filed_at": "2026-05-10T08:00:00.000000",
     "content": "FRICTION: Empty writer_agent — must be rejected per schema\n\nwriter_agent:\nsubcategory: should-be-rejected\ncanonical: https://github.com/hcross/crewrig\nseverity: med\nevidence:\n  - foo.md:1"
+  },
+  {
+    "drawer_id": "drw-007",
+    "room": "tool",
+    "filed_at": "2026-05-07T10:00:00.000000",
+    "content": "FRICTION: Already-correlated friction must be skipped by the curator\n\nwriter_agent: claude-code\nsubcategory: stale-resolved-fixture\ncanonical: https://github.com/hcross/crewrig\nseverity: high\nevidence:\n  - community-config/skills/harness-curator/scripts/apply.py:99\nsuggestion: Skip on truthy opened_as.\nopened_as: https://github.com/hcross/crewrig/issues/99"
   }
 ]

--- a/.gemini/skills/harness-curator/scripts/apply.py
+++ b/.gemini/skills/harness-curator/scripts/apply.py
@@ -15,6 +15,7 @@ run the script standalone for debugging.
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 
@@ -33,6 +34,21 @@ def _build_cmd(cluster: dict) -> list[str]:
     for lbl in labels:
         cmd.extend(["--label", lbl])
     return cmd
+
+
+def _collect_drawer_ids(cluster: dict) -> tuple[list[str], int]:
+    """Return (present_ids, missing_count). Caller emits a stderr warning
+    when missing > 0 so frictions without `_drawer_id` are surfaced rather
+    than silently dropped from the write-back set."""
+    ids: list[str] = []
+    missing = 0
+    for fr in cluster.get("frictions", []):
+        did = fr.get("_drawer_id")
+        if did:
+            ids.append(did)
+        else:
+            missing += 1
+    return ids, missing
 
 
 def main() -> int:
@@ -56,29 +72,35 @@ def main() -> int:
             # Issue #69: surface the drawers that would receive the
             # `opened_as` correlation stamp. Object shape (not array) so
             # existing argv-array assertions (`grep '^\['`) ignore it.
-            drawer_ids = [
-                fr.get("_drawer_id", "")
-                for fr in c.get("frictions", [])
-                if fr.get("_drawer_id")
-            ]
+            drawer_ids, missing = _collect_drawer_ids(c)
+            if missing:
+                print(
+                    f"  warn: cluster '{c['cluster_key']}' has {missing} "
+                    "friction(s) without _drawer_id; will not be stamped.",
+                    file=sys.stderr,
+                )
             print(json.dumps({
                 "would_update_drawers": drawer_ids,
                 "cluster_key": c["cluster_key"],
             }))
         return 0
 
-    # Lazy import: only the real --apply path needs mempalace MCP. The
-    # dry-run path above must stay import-free (curate.py owns the
-    # stdout-hijack workaround at module load — apply.py runs as a
-    # standalone process and would inherit no such protection).
+    # Real --apply path. Capture a duped fd 1 BEFORE importing
+    # mempalace.mcp_server — that import swaps sys.stdout to keep the
+    # MCP JSON-RPC channel clean (same hazard documented in
+    # config/TOOLS.md and motivating curate.py's module-top dup). Result
+    # URLs and the run summary go through _real_stdout so the caller
+    # can capture them; progress messages route to stderr explicitly.
+    _real_stdout = os.fdopen(os.dup(1), "w", encoding="utf-8", closefd=False)
     from mempalace.mcp_server import tool_get_drawer, tool_update_drawer
 
     opened = []
     failures = []
+    writeback_failures = 0
     for c in clusters:
         target = c["target_repo"]
         title = c["title"]
-        print(f"--- Opening issue on {target}: {title}")
+        print(f"--- Opening issue on {target}: {title}", file=sys.stderr)
         cmd = _build_cmd(c)
         try:
             result = subprocess.run(cmd, check=True, capture_output=True, text=True)
@@ -88,17 +110,24 @@ def main() -> int:
             # contributed to the cluster (issue #69). Re-fetch then
             # update because tool_update_drawer REPLACES content; this
             # narrows the clobber window against concurrent edits.
-            # Partial failures are logged but do NOT mark the cluster
-            # failed — the issue is already opened on GitHub.
-            for fr in c.get("frictions", []):
-                did = fr.get("_drawer_id")
-                if not did:
-                    continue
+            # Partial failures are counted and logged but do NOT mark
+            # the cluster failed — the issue is already opened on
+            # GitHub. The aggregate is surfaced in the final summary so
+            # the maintainer sees that some drawers remain unstamped.
+            drawer_ids, missing = _collect_drawer_ids(c)
+            if missing:
+                print(
+                    f"  warn: cluster '{c['cluster_key']}' has {missing} "
+                    "friction(s) without _drawer_id; will not be stamped.",
+                    file=sys.stderr,
+                )
+            for did in drawer_ids:
                 try:
                     drawer = tool_get_drawer(drawer_id=did)
                     new_content = drawer["content"].rstrip() + f"\nopened_as: {url}\n"
                     tool_update_drawer(drawer_id=did, content=new_content)
                 except Exception as wb_err:  # noqa: BLE001 — best-effort write-back
+                    writeback_failures += 1
                     print(
                         f"  warn: failed to stamp opened_as on drawer {did}: {wb_err}",
                         file=sys.stderr,
@@ -106,10 +135,17 @@ def main() -> int:
         except subprocess.CalledProcessError as e:
             failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
 
-    print()
-    print(f"Opened: {len(opened)} issue(s)")
+    print("", file=_real_stdout)
+    print(f"Opened: {len(opened)} issue(s)", file=_real_stdout)
     for o in opened:
-        print(f"  - {o['cluster']}: {o['url']}")
+        print(f"  - {o['cluster']}: {o['url']}", file=_real_stdout)
+    _real_stdout.flush()
+    if writeback_failures:
+        print(
+            f"Write-back failures: {writeback_failures} drawer(s) not stamped; "
+            "next curator run may re-open these issues.",
+            file=sys.stderr,
+        )
     if failures:
         print(f"Failures: {len(failures)}", file=sys.stderr)
         for f in failures:

--- a/.gemini/skills/harness-curator/scripts/apply.py
+++ b/.gemini/skills/harness-curator/scripts/apply.py
@@ -53,7 +53,25 @@ def main() -> int:
     if args.dry_run_apply:
         for c in clusters:
             print(json.dumps(_build_cmd(c)))
+            # Issue #69: surface the drawers that would receive the
+            # `opened_as` correlation stamp. Object shape (not array) so
+            # existing argv-array assertions (`grep '^\['`) ignore it.
+            drawer_ids = [
+                fr.get("_drawer_id", "")
+                for fr in c.get("frictions", [])
+                if fr.get("_drawer_id")
+            ]
+            print(json.dumps({
+                "would_update_drawers": drawer_ids,
+                "cluster_key": c["cluster_key"],
+            }))
         return 0
+
+    # Lazy import: only the real --apply path needs mempalace MCP. The
+    # dry-run path above must stay import-free (curate.py owns the
+    # stdout-hijack workaround at module load — apply.py runs as a
+    # standalone process and would inherit no such protection).
+    from mempalace.mcp_server import tool_get_drawer, tool_update_drawer
 
     opened = []
     failures = []
@@ -64,7 +82,27 @@ def main() -> int:
         cmd = _build_cmd(c)
         try:
             result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-            opened.append({"cluster": c["cluster_key"], "url": result.stdout.strip()})
+            url = result.stdout.strip()
+            opened.append({"cluster": c["cluster_key"], "url": url})
+            # Write-back: stamp `opened_as: <url>` on every drawer that
+            # contributed to the cluster (issue #69). Re-fetch then
+            # update because tool_update_drawer REPLACES content; this
+            # narrows the clobber window against concurrent edits.
+            # Partial failures are logged but do NOT mark the cluster
+            # failed — the issue is already opened on GitHub.
+            for fr in c.get("frictions", []):
+                did = fr.get("_drawer_id")
+                if not did:
+                    continue
+                try:
+                    drawer = tool_get_drawer(drawer_id=did)
+                    new_content = drawer["content"].rstrip() + f"\nopened_as: {url}\n"
+                    tool_update_drawer(drawer_id=did, content=new_content)
+                except Exception as wb_err:  # noqa: BLE001 — best-effort write-back
+                    print(
+                        f"  warn: failed to stamp opened_as on drawer {did}: {wb_err}",
+                        file=sys.stderr,
+                    )
         except subprocess.CalledProcessError as e:
             failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
 

--- a/.gemini/skills/harness-curator/scripts/curate.py
+++ b/.gemini/skills/harness-curator/scripts/curate.py
@@ -16,6 +16,7 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
         "total_drawers": int,
         "valid_frictions": int,
         "skipped_malformed": int,
+        "skipped_resolved": int,
         "clusters_formed": int,
         "clusters_above_threshold": int,
         "clusters_parked": int,
@@ -82,11 +83,22 @@ KV_RE = re.compile(r"^([a-z_][a-z0-9_]*):\s*(.*)$")
 LIST_RE = re.compile(r"^\s*-\s+(.+)$")
 
 
-def parse_friction(content: str) -> Optional[Dict[str, Any]]:
-    """Parse one FRICTION: payload. Return None if required fields are
-    missing — the caller treats None as "skip as malformed"."""
+def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
+    """Parse one FRICTION: payload.
+
+    Returns ``(payload, reason)``:
+      * ``(dict, "ok")``  — well-formed and still open (no ``opened_as:``).
+      * ``(None, "resolved")`` — well-formed but already correlated with a
+        GitHub issue (carries ``opened_as: <url>``). Caller skips silently
+        so the curator does not re-open issues for drawers that already
+        have one (issue #69).
+      * ``(None, "malformed")`` — missing required fields or no title.
+
+    The schema co-evolves with ``config/TOOLS.md``: ``opened_as`` is the
+    correlation field stamped on each drawer by ``apply.py`` after a
+    successful ``gh issue create``."""
     if not content:
-        return None
+        return None, "malformed"
     lines = content.splitlines()
     title = None
     body_start = 0
@@ -96,12 +108,12 @@ def parse_friction(content: str) -> Optional[Dict[str, Any]]:
             continue
         m = TITLE_RE.match(line.strip())
         if not m:
-            return None
+            return None, "malformed"
         title = m.group(1).strip()
         body_start = i + 1
         break
     if title is None:
-        return None
+        return None, "malformed"
 
     out: Dict[str, Any] = {"title": title, "evidence": []}
     in_evidence = False
@@ -129,12 +141,18 @@ def parse_friction(content: str) -> Optional[Dict[str, Any]]:
 
     # Required fields per config/TOOLS.md: writer_agent + ≥1 evidence.
     if not out.get("writer_agent"):
-        return None
+        return None, "malformed"
     if not out["evidence"]:
-        return None
+        return None, "malformed"
     # Default severity if absent.
     out.setdefault("severity", "med")
-    return out
+    # Skip drawers already correlated with an open/closed issue: the
+    # write-back stamp from apply.py (issue #69). We treat any truthy
+    # `opened_as` value as a resolved correlation — even if it's not a
+    # valid URL, the curator's job is just to avoid re-opening.
+    if out.get("opened_as"):
+        return None, "resolved"
+    return out, "ok"
 
 
 # --- Data sources ---------------------------------------------------------
@@ -205,17 +223,19 @@ def cluster_key_for(friction: Dict[str, Any], room: str) -> str:
 
 
 def cluster_frictions(
-    parsed: List[Tuple[Dict[str, Any], str, str]],
+    parsed: List[Tuple[Dict[str, Any], str, str, str]],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Group parsed frictions by cluster key. Each value entry stores the
-    friction with its room and filed_at glued in for downstream
-    traceability and for date-range computation in the MR body."""
+    friction with its room, filed_at and drawer_id glued in for downstream
+    traceability, date-range computation in the MR body, and post-create
+    write-back of the ``opened_as`` correlation field (issue #69)."""
     clusters: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
-    for friction, room, filed_at in parsed:
+    for friction, room, filed_at, drawer_id in parsed:
         key = cluster_key_for(friction, room)
         enriched = dict(friction)
         enriched["_room"] = room
         enriched["_filed_at"] = filed_at
+        enriched["_drawer_id"] = drawer_id
         clusters[key].append(enriched)
     return dict(clusters)
 
@@ -410,22 +430,27 @@ def main() -> int:
         "total_drawers": len(drawers),
         "valid_frictions": 0,
         "skipped_malformed": 0,
+        "skipped_resolved": 0,
         "clusters_formed": 0,
         "clusters_above_threshold": 0,
         "clusters_parked": 0,
         "routing_failures": 0,
     }
 
-    parsed: List[Tuple[Dict[str, Any], str, str]] = []
+    parsed: List[Tuple[Dict[str, Any], str, str, str]] = []
     for drawer in drawers:
         content = drawer.get("content", "")
         room = drawer.get("room", "")
         filed_at = drawer.get("filed_at", "")
-        friction = parse_friction(content)
+        drawer_id = drawer.get("drawer_id", "")
+        friction, reason = parse_friction(content)
         if friction is None:
-            stats["skipped_malformed"] += 1
+            if reason == "resolved":
+                stats["skipped_resolved"] += 1
+            else:
+                stats["skipped_malformed"] += 1
             continue
-        parsed.append((friction, room, filed_at))
+        parsed.append((friction, room, filed_at, drawer_id))
         stats["valid_frictions"] += 1
 
     clusters = cluster_frictions(parsed)

--- a/.gemini/skills/harness-curator/scripts/test.sh
+++ b/.gemini/skills/harness-curator/scripts/test.sh
@@ -61,14 +61,22 @@ assert() {
   fi
 }
 
-# 6 input drawers
-assert "stats.total_drawers"       "6" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+# 7 input drawers (drw-007 added to exercise the opened_as dedup path)
+assert "stats.total_drawers"       "7" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
 
-# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty writer_agent)
+# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty
+# writer_agent). drw-007 is well-formed but already correlated → counted
+# in skipped_resolved, NOT in skipped_malformed or valid_frictions.
 assert "stats.valid_frictions"     "4" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
 assert "stats.skipped_malformed"   "2" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
 
-# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton
+# Regression for issue #69: drw-007 carries `opened_as: <url>` and must be
+# filtered before clustering so the curator does not re-open an issue.
+assert "stats.skipped_resolved"    "1" "$(echo "$OUT" | jq -r '.stats.skipped_resolved')"
+
+# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton.
+# drw-007 is filtered upstream of clustering, so its subcategory must not
+# appear as a cluster key — see the explicit assertion further down.
 assert "stats.clusters_formed"     "3" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
 
 # Above threshold:
@@ -152,6 +160,18 @@ PARKED=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "parked-singl
 [ -z "$PARKED" ] || { echo "FAIL: parked-singleton should be parked, not in clusters" >&2; exit 1; }
 echo "  PASS parked-singleton excluded from output"
 
+# Regression for issue #69: the resolved drawer's subcategory must never
+# surface as a cluster_key. drw-007 is severity:high, so absent the
+# pre-cluster skip filter it would qualify as a high-severity singleton
+# bypass and pollute the output. Its absence proves the filter ran.
+RESOLVED_CLUSTER=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "stale-resolved-fixture")')
+[ -z "$RESOLVED_CLUSTER" ] || {
+  echo "FAIL: resolved drawer (drw-007) subcategory leaked into clusters" >&2
+  echo "$RESOLVED_CLUSTER" >&2
+  exit 1
+}
+echo "  PASS resolved-drawer subcategory absent from clusters"
+
 # --- apply.py orchestration (--dry-run-apply) ----------------------------
 # Pipe the curator JSON through apply.py --dry-run-apply. Each cluster
 # round-trips as one JSON-array line representing the `gh issue create`
@@ -167,8 +187,35 @@ set -e
 assert "apply --dry-run-apply exit code" "0" "$APPLY_RC"
 
 # Two qualified clusters → exactly two argv lines, no spurious output.
+# (apply.py now emits a sibling object line per cluster carrying the
+# would_update_drawers list — that line starts with `{`, so the `^\[`
+# filter still counts only argv arrays.)
 APPLY_LINES=$(printf '%s\n' "$APPLY_OUT" | grep -c '^\[')
 assert "apply --dry-run-apply emits one argv line per cluster" "2" "$APPLY_LINES"
+
+# Issue #69: alongside each argv array, apply.py emits a JSON object line
+# `{"would_update_drawers": [...], "cluster_key": "..."}` so the
+# orchestration shape now exposes the drawers that would receive the
+# `opened_as` write-back. Two qualified clusters → two object lines.
+APPLY_OBJECTS=$(printf '%s\n' "$APPLY_OUT" | jq -c 'select(type == "object" and (.would_update_drawers // null) != null)' 2>/dev/null || true)
+APPLY_OBJ_COUNT=$(printf '%s\n' "$APPLY_OBJECTS" | grep -c .)
+assert "apply --dry-run-apply emits one would_update_drawers object per cluster" \
+  "2" "$APPLY_OBJ_COUNT"
+
+# yq-merge object: 2 source drawers (drw-001, drw-002) propagated via _drawer_id.
+YQ_OBJ=$(printf '%s\n' "$APPLY_OBJECTS" | jq -c 'select(.cluster_key == "yq-merge")')
+[ -n "$YQ_OBJ" ] || { echo "FAIL: yq-merge would_update_drawers object missing" >&2; exit 1; }
+assert "yq-merge would_update_drawers type"   "array"   "$(echo "$YQ_OBJ" | jq -r '.would_update_drawers | type')"
+assert "yq-merge would_update_drawers length" "2"       "$(echo "$YQ_OBJ" | jq -r '.would_update_drawers | length')"
+assert "yq-merge would_update_drawers cluster_key" "yq-merge" "$(echo "$YQ_OBJ" | jq -r '.cluster_key')"
+
+# gh-body-truncation object: severity:high singleton → exactly 1 drawer (drw-003).
+HIGH_OBJ=$(printf '%s\n' "$APPLY_OBJECTS" | jq -c 'select(.cluster_key == "gh-body-truncation")')
+[ -n "$HIGH_OBJ" ] || { echo "FAIL: gh-body-truncation would_update_drawers object missing" >&2; exit 1; }
+assert "gh-body-truncation would_update_drawers cluster_key" "gh-body-truncation" \
+  "$(echo "$HIGH_OBJ" | jq -r '.cluster_key')"
+assert "gh-body-truncation would_update_drawers length" "1" \
+  "$(echo "$HIGH_OBJ" | jq -r '.would_update_drawers | length')"
 
 # Helper jq filter: collect all `--label <value>` pairs as a list, in order.
 LABELS_FILTER='[. as $a | range(length) | select($a[.] == "--label") | $a[.+1]]'
@@ -261,10 +308,17 @@ else
 
   # Seed exactly one drawer that qualifies as a singleton via the
   # severity:high bypass. Title prefix and the writer_agent / evidence
-  # keys mirror the schema in assets/sample-frictions.json.
-  "$MEMPALACE_PYTHON" - <<'PY'
+  # keys mirror the schema in assets/sample-frictions.json. The
+  # tool_add_drawer return value carries the assigned drawer_id; capture
+  # it for the round-trip assertions below (issue #69).
+  SEEDED_DRAWER_ID=$("$MEMPALACE_PYTHON" - <<'PY'
+# Mirror curate.py: dup fd 1 BEFORE importing mempalace.mcp_server, which
+# swaps sys.stdout for the JSON-RPC channel and would otherwise eat our
+# drawer_id capture.
+import os
+_real = os.fdopen(os.dup(1), "w", encoding="utf-8", closefd=False)
 from mempalace.mcp_server import tool_add_drawer
-tool_add_drawer(
+result = tool_add_drawer(
     wing="harness-friction",
     room="tool",
     content=(
@@ -277,7 +331,15 @@ tool_add_drawer(
         "  - community-config/skills/harness-curator/scripts/curate.py:60\n"
     ),
 )
+_real.write(result.get("drawer_id", "") if isinstance(result, dict) else str(result))
+_real.flush()
 PY
+)
+  [ -n "$SEEDED_DRAWER_ID" ] || {
+    echo "FAIL test_real: tool_add_drawer returned no drawer_id" >&2
+    exit 1
+  }
+  echo "  PASS test_real seeded drawer ($SEEDED_DRAWER_ID)"
 
   # Run curate.sh with NO --from-stdin so the real read_from_mempalace
   # path executes. Split stdout / stderr — mempalace chatter on stderr
@@ -322,6 +384,65 @@ PY
     "$(echo "$REAL_OUT" | jq -r '.stats.clusters_above_threshold')"
   assert "test_real.cluster_key" "real-mempalace-smoke" \
     "$(echo "$REAL_OUT" | jq -r '.clusters[0].cluster_key')"
+
+  # --- Issue #69 round-trip: _drawer_id propagation + write-back skip ----
+  # Pipe the real-MemPalace curator output through apply.py --dry-run-apply
+  # and assert that the would_update_drawers list carries the exact
+  # drawer_id returned at seed time. This proves _drawer_id propagates
+  # from tool_list_drawers → cluster JSON → apply.py argv-build.
+  set +e
+  REAL_APPLY_OUT=$(printf '%s\n' "$REAL_OUT" | python3 "$APPLY" --dry-run-apply)
+  REAL_APPLY_RC=$?
+  set -e
+  assert "test_real apply --dry-run-apply exit code" "0" "$REAL_APPLY_RC"
+
+  REAL_APPLY_OBJ=$(printf '%s\n' "$REAL_APPLY_OUT" | jq -c 'select(type == "object" and (.would_update_drawers // null) != null)')
+  [ -n "$REAL_APPLY_OBJ" ] || {
+    echo "FAIL test_real apply.would_update_drawers object missing" >&2
+    echo "$REAL_APPLY_OUT" >&2
+    exit 1
+  }
+  REAL_APPLY_IDS=$(echo "$REAL_APPLY_OBJ" | jq -c '.would_update_drawers')
+  assert "test_real would_update_drawers carries seeded drawer_id" \
+    "[\"$SEEDED_DRAWER_ID\"]" "$REAL_APPLY_IDS"
+
+  # Simulate the real --apply write-back: stamp `opened_as: <url>` on the
+  # seeded drawer the same way apply.py's real path does. The fd-dup
+  # mirrors the seed script — mempalace.mcp_server swaps sys.stdout on
+  # import.
+  "$MEMPALACE_PYTHON" - "$SEEDED_DRAWER_ID" <<'PY'
+import os, sys
+_real = os.fdopen(os.dup(1), "w", encoding="utf-8", closefd=False)
+from mempalace.mcp_server import tool_get_drawer, tool_update_drawer
+did = sys.argv[1]
+drawer = tool_get_drawer(drawer_id=did)
+new_content = drawer["content"].rstrip() + "\nopened_as: https://example.com/fake/1\n"
+tool_update_drawer(drawer_id=did, content=new_content)
+_real.write("ok")
+_real.flush()
+PY
+
+  # Re-run curate; the freshly stamped drawer must now be filtered as
+  # `resolved`, leaving zero valid frictions and zero clusters.
+  set +e
+  bash "$SCRIPT" --dry-run >"$tmpdir/out2.json" 2>"$tmpdir/err2.log"
+  REAL_RC2=$?
+  set -e
+  assert "test_real second-run exit code" "0" "$REAL_RC2"
+  REAL_OUT2=$(cat "$tmpdir/out2.json")
+  assert "test_real second-run stats.skipped_resolved" "1" \
+    "$(echo "$REAL_OUT2" | jq -r '.stats.skipped_resolved')"
+  assert "test_real second-run stats.valid_frictions" "0" \
+    "$(echo "$REAL_OUT2" | jq -r '.stats.valid_frictions')"
+  assert "test_real second-run stats.clusters_above_threshold" "0" \
+    "$(echo "$REAL_OUT2" | jq -r '.stats.clusters_above_threshold')"
+  RESOLVED_LEAK=$(echo "$REAL_OUT2" | jq -c '.clusters[] | select(.cluster_key == "real-mempalace-smoke")')
+  [ -z "$RESOLVED_LEAK" ] || {
+    echo "FAIL test_real second-run: stamped drawer leaked into clusters" >&2
+    echo "$RESOLVED_LEAK" >&2
+    exit 1
+  }
+  echo "  PASS test_real second-run: stamped drawer absent from clusters"
 fi
 
 echo ""

--- a/community-config/skills/harness-curator/assets/sample-frictions.json
+++ b/community-config/skills/harness-curator/assets/sample-frictions.json
@@ -32,5 +32,11 @@
     "room": "prompt",
     "filed_at": "2026-05-10T08:00:00.000000",
     "content": "FRICTION: Empty writer_agent — must be rejected per schema\n\nwriter_agent:\nsubcategory: should-be-rejected\ncanonical: https://github.com/hcross/crewrig\nseverity: med\nevidence:\n  - foo.md:1"
+  },
+  {
+    "drawer_id": "drw-007",
+    "room": "tool",
+    "filed_at": "2026-05-07T10:00:00.000000",
+    "content": "FRICTION: Already-correlated friction must be skipped by the curator\n\nwriter_agent: claude-code\nsubcategory: stale-resolved-fixture\ncanonical: https://github.com/hcross/crewrig\nseverity: high\nevidence:\n  - community-config/skills/harness-curator/scripts/apply.py:99\nsuggestion: Skip on truthy opened_as.\nopened_as: https://github.com/hcross/crewrig/issues/99"
   }
 ]

--- a/community-config/skills/harness-curator/scripts/apply.py
+++ b/community-config/skills/harness-curator/scripts/apply.py
@@ -15,6 +15,7 @@ run the script standalone for debugging.
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 
@@ -33,6 +34,21 @@ def _build_cmd(cluster: dict) -> list[str]:
     for lbl in labels:
         cmd.extend(["--label", lbl])
     return cmd
+
+
+def _collect_drawer_ids(cluster: dict) -> tuple[list[str], int]:
+    """Return (present_ids, missing_count). Caller emits a stderr warning
+    when missing > 0 so frictions without `_drawer_id` are surfaced rather
+    than silently dropped from the write-back set."""
+    ids: list[str] = []
+    missing = 0
+    for fr in cluster.get("frictions", []):
+        did = fr.get("_drawer_id")
+        if did:
+            ids.append(did)
+        else:
+            missing += 1
+    return ids, missing
 
 
 def main() -> int:
@@ -56,29 +72,35 @@ def main() -> int:
             # Issue #69: surface the drawers that would receive the
             # `opened_as` correlation stamp. Object shape (not array) so
             # existing argv-array assertions (`grep '^\['`) ignore it.
-            drawer_ids = [
-                fr.get("_drawer_id", "")
-                for fr in c.get("frictions", [])
-                if fr.get("_drawer_id")
-            ]
+            drawer_ids, missing = _collect_drawer_ids(c)
+            if missing:
+                print(
+                    f"  warn: cluster '{c['cluster_key']}' has {missing} "
+                    "friction(s) without _drawer_id; will not be stamped.",
+                    file=sys.stderr,
+                )
             print(json.dumps({
                 "would_update_drawers": drawer_ids,
                 "cluster_key": c["cluster_key"],
             }))
         return 0
 
-    # Lazy import: only the real --apply path needs mempalace MCP. The
-    # dry-run path above must stay import-free (curate.py owns the
-    # stdout-hijack workaround at module load — apply.py runs as a
-    # standalone process and would inherit no such protection).
+    # Real --apply path. Capture a duped fd 1 BEFORE importing
+    # mempalace.mcp_server — that import swaps sys.stdout to keep the
+    # MCP JSON-RPC channel clean (same hazard documented in
+    # config/TOOLS.md and motivating curate.py's module-top dup). Result
+    # URLs and the run summary go through _real_stdout so the caller
+    # can capture them; progress messages route to stderr explicitly.
+    _real_stdout = os.fdopen(os.dup(1), "w", encoding="utf-8", closefd=False)
     from mempalace.mcp_server import tool_get_drawer, tool_update_drawer
 
     opened = []
     failures = []
+    writeback_failures = 0
     for c in clusters:
         target = c["target_repo"]
         title = c["title"]
-        print(f"--- Opening issue on {target}: {title}")
+        print(f"--- Opening issue on {target}: {title}", file=sys.stderr)
         cmd = _build_cmd(c)
         try:
             result = subprocess.run(cmd, check=True, capture_output=True, text=True)
@@ -88,17 +110,24 @@ def main() -> int:
             # contributed to the cluster (issue #69). Re-fetch then
             # update because tool_update_drawer REPLACES content; this
             # narrows the clobber window against concurrent edits.
-            # Partial failures are logged but do NOT mark the cluster
-            # failed — the issue is already opened on GitHub.
-            for fr in c.get("frictions", []):
-                did = fr.get("_drawer_id")
-                if not did:
-                    continue
+            # Partial failures are counted and logged but do NOT mark
+            # the cluster failed — the issue is already opened on
+            # GitHub. The aggregate is surfaced in the final summary so
+            # the maintainer sees that some drawers remain unstamped.
+            drawer_ids, missing = _collect_drawer_ids(c)
+            if missing:
+                print(
+                    f"  warn: cluster '{c['cluster_key']}' has {missing} "
+                    "friction(s) without _drawer_id; will not be stamped.",
+                    file=sys.stderr,
+                )
+            for did in drawer_ids:
                 try:
                     drawer = tool_get_drawer(drawer_id=did)
                     new_content = drawer["content"].rstrip() + f"\nopened_as: {url}\n"
                     tool_update_drawer(drawer_id=did, content=new_content)
                 except Exception as wb_err:  # noqa: BLE001 — best-effort write-back
+                    writeback_failures += 1
                     print(
                         f"  warn: failed to stamp opened_as on drawer {did}: {wb_err}",
                         file=sys.stderr,
@@ -106,10 +135,17 @@ def main() -> int:
         except subprocess.CalledProcessError as e:
             failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
 
-    print()
-    print(f"Opened: {len(opened)} issue(s)")
+    print("", file=_real_stdout)
+    print(f"Opened: {len(opened)} issue(s)", file=_real_stdout)
     for o in opened:
-        print(f"  - {o['cluster']}: {o['url']}")
+        print(f"  - {o['cluster']}: {o['url']}", file=_real_stdout)
+    _real_stdout.flush()
+    if writeback_failures:
+        print(
+            f"Write-back failures: {writeback_failures} drawer(s) not stamped; "
+            "next curator run may re-open these issues.",
+            file=sys.stderr,
+        )
     if failures:
         print(f"Failures: {len(failures)}", file=sys.stderr)
         for f in failures:

--- a/community-config/skills/harness-curator/scripts/apply.py
+++ b/community-config/skills/harness-curator/scripts/apply.py
@@ -53,7 +53,25 @@ def main() -> int:
     if args.dry_run_apply:
         for c in clusters:
             print(json.dumps(_build_cmd(c)))
+            # Issue #69: surface the drawers that would receive the
+            # `opened_as` correlation stamp. Object shape (not array) so
+            # existing argv-array assertions (`grep '^\['`) ignore it.
+            drawer_ids = [
+                fr.get("_drawer_id", "")
+                for fr in c.get("frictions", [])
+                if fr.get("_drawer_id")
+            ]
+            print(json.dumps({
+                "would_update_drawers": drawer_ids,
+                "cluster_key": c["cluster_key"],
+            }))
         return 0
+
+    # Lazy import: only the real --apply path needs mempalace MCP. The
+    # dry-run path above must stay import-free (curate.py owns the
+    # stdout-hijack workaround at module load — apply.py runs as a
+    # standalone process and would inherit no such protection).
+    from mempalace.mcp_server import tool_get_drawer, tool_update_drawer
 
     opened = []
     failures = []
@@ -64,7 +82,27 @@ def main() -> int:
         cmd = _build_cmd(c)
         try:
             result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-            opened.append({"cluster": c["cluster_key"], "url": result.stdout.strip()})
+            url = result.stdout.strip()
+            opened.append({"cluster": c["cluster_key"], "url": url})
+            # Write-back: stamp `opened_as: <url>` on every drawer that
+            # contributed to the cluster (issue #69). Re-fetch then
+            # update because tool_update_drawer REPLACES content; this
+            # narrows the clobber window against concurrent edits.
+            # Partial failures are logged but do NOT mark the cluster
+            # failed — the issue is already opened on GitHub.
+            for fr in c.get("frictions", []):
+                did = fr.get("_drawer_id")
+                if not did:
+                    continue
+                try:
+                    drawer = tool_get_drawer(drawer_id=did)
+                    new_content = drawer["content"].rstrip() + f"\nopened_as: {url}\n"
+                    tool_update_drawer(drawer_id=did, content=new_content)
+                except Exception as wb_err:  # noqa: BLE001 — best-effort write-back
+                    print(
+                        f"  warn: failed to stamp opened_as on drawer {did}: {wb_err}",
+                        file=sys.stderr,
+                    )
         except subprocess.CalledProcessError as e:
             failures.append({"cluster": c["cluster_key"], "error": e.stderr.strip()})
 

--- a/community-config/skills/harness-curator/scripts/curate.py
+++ b/community-config/skills/harness-curator/scripts/curate.py
@@ -16,6 +16,7 @@ Output JSON schema (stable, depended on by ``scripts/harness-curate.sh``):
         "total_drawers": int,
         "valid_frictions": int,
         "skipped_malformed": int,
+        "skipped_resolved": int,
         "clusters_formed": int,
         "clusters_above_threshold": int,
         "clusters_parked": int,
@@ -82,11 +83,22 @@ KV_RE = re.compile(r"^([a-z_][a-z0-9_]*):\s*(.*)$")
 LIST_RE = re.compile(r"^\s*-\s+(.+)$")
 
 
-def parse_friction(content: str) -> Optional[Dict[str, Any]]:
-    """Parse one FRICTION: payload. Return None if required fields are
-    missing — the caller treats None as "skip as malformed"."""
+def parse_friction(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
+    """Parse one FRICTION: payload.
+
+    Returns ``(payload, reason)``:
+      * ``(dict, "ok")``  — well-formed and still open (no ``opened_as:``).
+      * ``(None, "resolved")`` — well-formed but already correlated with a
+        GitHub issue (carries ``opened_as: <url>``). Caller skips silently
+        so the curator does not re-open issues for drawers that already
+        have one (issue #69).
+      * ``(None, "malformed")`` — missing required fields or no title.
+
+    The schema co-evolves with ``config/TOOLS.md``: ``opened_as`` is the
+    correlation field stamped on each drawer by ``apply.py`` after a
+    successful ``gh issue create``."""
     if not content:
-        return None
+        return None, "malformed"
     lines = content.splitlines()
     title = None
     body_start = 0
@@ -96,12 +108,12 @@ def parse_friction(content: str) -> Optional[Dict[str, Any]]:
             continue
         m = TITLE_RE.match(line.strip())
         if not m:
-            return None
+            return None, "malformed"
         title = m.group(1).strip()
         body_start = i + 1
         break
     if title is None:
-        return None
+        return None, "malformed"
 
     out: Dict[str, Any] = {"title": title, "evidence": []}
     in_evidence = False
@@ -129,12 +141,18 @@ def parse_friction(content: str) -> Optional[Dict[str, Any]]:
 
     # Required fields per config/TOOLS.md: writer_agent + ≥1 evidence.
     if not out.get("writer_agent"):
-        return None
+        return None, "malformed"
     if not out["evidence"]:
-        return None
+        return None, "malformed"
     # Default severity if absent.
     out.setdefault("severity", "med")
-    return out
+    # Skip drawers already correlated with an open/closed issue: the
+    # write-back stamp from apply.py (issue #69). We treat any truthy
+    # `opened_as` value as a resolved correlation — even if it's not a
+    # valid URL, the curator's job is just to avoid re-opening.
+    if out.get("opened_as"):
+        return None, "resolved"
+    return out, "ok"
 
 
 # --- Data sources ---------------------------------------------------------
@@ -205,17 +223,19 @@ def cluster_key_for(friction: Dict[str, Any], room: str) -> str:
 
 
 def cluster_frictions(
-    parsed: List[Tuple[Dict[str, Any], str, str]],
+    parsed: List[Tuple[Dict[str, Any], str, str, str]],
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Group parsed frictions by cluster key. Each value entry stores the
-    friction with its room and filed_at glued in for downstream
-    traceability and for date-range computation in the MR body."""
+    friction with its room, filed_at and drawer_id glued in for downstream
+    traceability, date-range computation in the MR body, and post-create
+    write-back of the ``opened_as`` correlation field (issue #69)."""
     clusters: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
-    for friction, room, filed_at in parsed:
+    for friction, room, filed_at, drawer_id in parsed:
         key = cluster_key_for(friction, room)
         enriched = dict(friction)
         enriched["_room"] = room
         enriched["_filed_at"] = filed_at
+        enriched["_drawer_id"] = drawer_id
         clusters[key].append(enriched)
     return dict(clusters)
 
@@ -410,22 +430,27 @@ def main() -> int:
         "total_drawers": len(drawers),
         "valid_frictions": 0,
         "skipped_malformed": 0,
+        "skipped_resolved": 0,
         "clusters_formed": 0,
         "clusters_above_threshold": 0,
         "clusters_parked": 0,
         "routing_failures": 0,
     }
 
-    parsed: List[Tuple[Dict[str, Any], str, str]] = []
+    parsed: List[Tuple[Dict[str, Any], str, str, str]] = []
     for drawer in drawers:
         content = drawer.get("content", "")
         room = drawer.get("room", "")
         filed_at = drawer.get("filed_at", "")
-        friction = parse_friction(content)
+        drawer_id = drawer.get("drawer_id", "")
+        friction, reason = parse_friction(content)
         if friction is None:
-            stats["skipped_malformed"] += 1
+            if reason == "resolved":
+                stats["skipped_resolved"] += 1
+            else:
+                stats["skipped_malformed"] += 1
             continue
-        parsed.append((friction, room, filed_at))
+        parsed.append((friction, room, filed_at, drawer_id))
         stats["valid_frictions"] += 1
 
     clusters = cluster_frictions(parsed)

--- a/community-config/skills/harness-curator/scripts/test.sh
+++ b/community-config/skills/harness-curator/scripts/test.sh
@@ -61,14 +61,22 @@ assert() {
   fi
 }
 
-# 6 input drawers
-assert "stats.total_drawers"       "6" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
+# 7 input drawers (drw-007 added to exercise the opened_as dedup path)
+assert "stats.total_drawers"       "7" "$(echo "$OUT" | jq -r '.stats.total_drawers')"
 
-# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty writer_agent)
+# 4 valid; 2 malformed: drw-005 (no FRICTION: prefix) and drw-006 (empty
+# writer_agent). drw-007 is well-formed but already correlated → counted
+# in skipped_resolved, NOT in skipped_malformed or valid_frictions.
 assert "stats.valid_frictions"     "4" "$(echo "$OUT" | jq -r '.stats.valid_frictions')"
 assert "stats.skipped_malformed"   "2" "$(echo "$OUT" | jq -r '.stats.skipped_malformed')"
 
-# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton
+# Regression for issue #69: drw-007 carries `opened_as: <url>` and must be
+# filtered before clustering so the curator does not re-open an issue.
+assert "stats.skipped_resolved"    "1" "$(echo "$OUT" | jq -r '.stats.skipped_resolved')"
+
+# 3 cluster keys: yq-merge, gh-body-truncation, parked-singleton.
+# drw-007 is filtered upstream of clustering, so its subcategory must not
+# appear as a cluster key — see the explicit assertion further down.
 assert "stats.clusters_formed"     "3" "$(echo "$OUT" | jq -r '.stats.clusters_formed')"
 
 # Above threshold:
@@ -152,6 +160,18 @@ PARKED=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "parked-singl
 [ -z "$PARKED" ] || { echo "FAIL: parked-singleton should be parked, not in clusters" >&2; exit 1; }
 echo "  PASS parked-singleton excluded from output"
 
+# Regression for issue #69: the resolved drawer's subcategory must never
+# surface as a cluster_key. drw-007 is severity:high, so absent the
+# pre-cluster skip filter it would qualify as a high-severity singleton
+# bypass and pollute the output. Its absence proves the filter ran.
+RESOLVED_CLUSTER=$(echo "$OUT" | jq -c '.clusters[] | select(.cluster_key == "stale-resolved-fixture")')
+[ -z "$RESOLVED_CLUSTER" ] || {
+  echo "FAIL: resolved drawer (drw-007) subcategory leaked into clusters" >&2
+  echo "$RESOLVED_CLUSTER" >&2
+  exit 1
+}
+echo "  PASS resolved-drawer subcategory absent from clusters"
+
 # --- apply.py orchestration (--dry-run-apply) ----------------------------
 # Pipe the curator JSON through apply.py --dry-run-apply. Each cluster
 # round-trips as one JSON-array line representing the `gh issue create`
@@ -167,8 +187,35 @@ set -e
 assert "apply --dry-run-apply exit code" "0" "$APPLY_RC"
 
 # Two qualified clusters → exactly two argv lines, no spurious output.
+# (apply.py now emits a sibling object line per cluster carrying the
+# would_update_drawers list — that line starts with `{`, so the `^\[`
+# filter still counts only argv arrays.)
 APPLY_LINES=$(printf '%s\n' "$APPLY_OUT" | grep -c '^\[')
 assert "apply --dry-run-apply emits one argv line per cluster" "2" "$APPLY_LINES"
+
+# Issue #69: alongside each argv array, apply.py emits a JSON object line
+# `{"would_update_drawers": [...], "cluster_key": "..."}` so the
+# orchestration shape now exposes the drawers that would receive the
+# `opened_as` write-back. Two qualified clusters → two object lines.
+APPLY_OBJECTS=$(printf '%s\n' "$APPLY_OUT" | jq -c 'select(type == "object" and (.would_update_drawers // null) != null)' 2>/dev/null || true)
+APPLY_OBJ_COUNT=$(printf '%s\n' "$APPLY_OBJECTS" | grep -c .)
+assert "apply --dry-run-apply emits one would_update_drawers object per cluster" \
+  "2" "$APPLY_OBJ_COUNT"
+
+# yq-merge object: 2 source drawers (drw-001, drw-002) propagated via _drawer_id.
+YQ_OBJ=$(printf '%s\n' "$APPLY_OBJECTS" | jq -c 'select(.cluster_key == "yq-merge")')
+[ -n "$YQ_OBJ" ] || { echo "FAIL: yq-merge would_update_drawers object missing" >&2; exit 1; }
+assert "yq-merge would_update_drawers type"   "array"   "$(echo "$YQ_OBJ" | jq -r '.would_update_drawers | type')"
+assert "yq-merge would_update_drawers length" "2"       "$(echo "$YQ_OBJ" | jq -r '.would_update_drawers | length')"
+assert "yq-merge would_update_drawers cluster_key" "yq-merge" "$(echo "$YQ_OBJ" | jq -r '.cluster_key')"
+
+# gh-body-truncation object: severity:high singleton → exactly 1 drawer (drw-003).
+HIGH_OBJ=$(printf '%s\n' "$APPLY_OBJECTS" | jq -c 'select(.cluster_key == "gh-body-truncation")')
+[ -n "$HIGH_OBJ" ] || { echo "FAIL: gh-body-truncation would_update_drawers object missing" >&2; exit 1; }
+assert "gh-body-truncation would_update_drawers cluster_key" "gh-body-truncation" \
+  "$(echo "$HIGH_OBJ" | jq -r '.cluster_key')"
+assert "gh-body-truncation would_update_drawers length" "1" \
+  "$(echo "$HIGH_OBJ" | jq -r '.would_update_drawers | length')"
 
 # Helper jq filter: collect all `--label <value>` pairs as a list, in order.
 LABELS_FILTER='[. as $a | range(length) | select($a[.] == "--label") | $a[.+1]]'
@@ -261,10 +308,17 @@ else
 
   # Seed exactly one drawer that qualifies as a singleton via the
   # severity:high bypass. Title prefix and the writer_agent / evidence
-  # keys mirror the schema in assets/sample-frictions.json.
-  "$MEMPALACE_PYTHON" - <<'PY'
+  # keys mirror the schema in assets/sample-frictions.json. The
+  # tool_add_drawer return value carries the assigned drawer_id; capture
+  # it for the round-trip assertions below (issue #69).
+  SEEDED_DRAWER_ID=$("$MEMPALACE_PYTHON" - <<'PY'
+# Mirror curate.py: dup fd 1 BEFORE importing mempalace.mcp_server, which
+# swaps sys.stdout for the JSON-RPC channel and would otherwise eat our
+# drawer_id capture.
+import os
+_real = os.fdopen(os.dup(1), "w", encoding="utf-8", closefd=False)
 from mempalace.mcp_server import tool_add_drawer
-tool_add_drawer(
+result = tool_add_drawer(
     wing="harness-friction",
     room="tool",
     content=(
@@ -277,7 +331,15 @@ tool_add_drawer(
         "  - community-config/skills/harness-curator/scripts/curate.py:60\n"
     ),
 )
+_real.write(result.get("drawer_id", "") if isinstance(result, dict) else str(result))
+_real.flush()
 PY
+)
+  [ -n "$SEEDED_DRAWER_ID" ] || {
+    echo "FAIL test_real: tool_add_drawer returned no drawer_id" >&2
+    exit 1
+  }
+  echo "  PASS test_real seeded drawer ($SEEDED_DRAWER_ID)"
 
   # Run curate.sh with NO --from-stdin so the real read_from_mempalace
   # path executes. Split stdout / stderr — mempalace chatter on stderr
@@ -322,6 +384,65 @@ PY
     "$(echo "$REAL_OUT" | jq -r '.stats.clusters_above_threshold')"
   assert "test_real.cluster_key" "real-mempalace-smoke" \
     "$(echo "$REAL_OUT" | jq -r '.clusters[0].cluster_key')"
+
+  # --- Issue #69 round-trip: _drawer_id propagation + write-back skip ----
+  # Pipe the real-MemPalace curator output through apply.py --dry-run-apply
+  # and assert that the would_update_drawers list carries the exact
+  # drawer_id returned at seed time. This proves _drawer_id propagates
+  # from tool_list_drawers → cluster JSON → apply.py argv-build.
+  set +e
+  REAL_APPLY_OUT=$(printf '%s\n' "$REAL_OUT" | python3 "$APPLY" --dry-run-apply)
+  REAL_APPLY_RC=$?
+  set -e
+  assert "test_real apply --dry-run-apply exit code" "0" "$REAL_APPLY_RC"
+
+  REAL_APPLY_OBJ=$(printf '%s\n' "$REAL_APPLY_OUT" | jq -c 'select(type == "object" and (.would_update_drawers // null) != null)')
+  [ -n "$REAL_APPLY_OBJ" ] || {
+    echo "FAIL test_real apply.would_update_drawers object missing" >&2
+    echo "$REAL_APPLY_OUT" >&2
+    exit 1
+  }
+  REAL_APPLY_IDS=$(echo "$REAL_APPLY_OBJ" | jq -c '.would_update_drawers')
+  assert "test_real would_update_drawers carries seeded drawer_id" \
+    "[\"$SEEDED_DRAWER_ID\"]" "$REAL_APPLY_IDS"
+
+  # Simulate the real --apply write-back: stamp `opened_as: <url>` on the
+  # seeded drawer the same way apply.py's real path does. The fd-dup
+  # mirrors the seed script — mempalace.mcp_server swaps sys.stdout on
+  # import.
+  "$MEMPALACE_PYTHON" - "$SEEDED_DRAWER_ID" <<'PY'
+import os, sys
+_real = os.fdopen(os.dup(1), "w", encoding="utf-8", closefd=False)
+from mempalace.mcp_server import tool_get_drawer, tool_update_drawer
+did = sys.argv[1]
+drawer = tool_get_drawer(drawer_id=did)
+new_content = drawer["content"].rstrip() + "\nopened_as: https://example.com/fake/1\n"
+tool_update_drawer(drawer_id=did, content=new_content)
+_real.write("ok")
+_real.flush()
+PY
+
+  # Re-run curate; the freshly stamped drawer must now be filtered as
+  # `resolved`, leaving zero valid frictions and zero clusters.
+  set +e
+  bash "$SCRIPT" --dry-run >"$tmpdir/out2.json" 2>"$tmpdir/err2.log"
+  REAL_RC2=$?
+  set -e
+  assert "test_real second-run exit code" "0" "$REAL_RC2"
+  REAL_OUT2=$(cat "$tmpdir/out2.json")
+  assert "test_real second-run stats.skipped_resolved" "1" \
+    "$(echo "$REAL_OUT2" | jq -r '.stats.skipped_resolved')"
+  assert "test_real second-run stats.valid_frictions" "0" \
+    "$(echo "$REAL_OUT2" | jq -r '.stats.valid_frictions')"
+  assert "test_real second-run stats.clusters_above_threshold" "0" \
+    "$(echo "$REAL_OUT2" | jq -r '.stats.clusters_above_threshold')"
+  RESOLVED_LEAK=$(echo "$REAL_OUT2" | jq -c '.clusters[] | select(.cluster_key == "real-mempalace-smoke")')
+  [ -z "$RESOLVED_LEAK" ] || {
+    echo "FAIL test_real second-run: stamped drawer leaked into clusters" >&2
+    echo "$RESOLVED_LEAK" >&2
+    exit 1
+  }
+  echo "  PASS test_real second-run: stamped drawer absent from clusters"
 fi
 
 echo ""


### PR DESCRIPTION
Wire a two-step bookkeeping loop into the Harness Curator so that drawers which produced a GitHub issue carry an `opened_as: <url>` back-pointer, and the next curator run skips them instead of re-opening duplicates. This closes the gap that surfaced twice in the harness skill-quality chain (curator opened #62 from a duplicate drawer; manual cleanup was required after the `/harness-curator` run that produced this branch).

## How to read this PR?

1. `community-config/skills/harness-curator/scripts/curate.py` — read first. `parse_friction()` signature changes from `Optional[Dict]` to `Tuple[Optional[Dict], str]`; the reason discriminates `ok` vs `malformed` vs new `resolved`. `cluster_frictions()` gains a `drawer_id` parameter and enriches each friction with `_drawer_id`. New stat `stats.skipped_resolved` rides alongside `skipped_malformed`.
2. `community-config/skills/harness-curator/scripts/apply.py` — read second. The dry-run path is unchanged in spirit but emits a second JSON object line per cluster (`{"would_update_drawers":[...], ...}`) so callers can preview write-backs. The apply path lazy-imports `mempalace.mcp_server` **after** the dry-run early-return, then re-fetches each contributing drawer via `tool_get_drawer` and writes the appended content via `tool_update_drawer`.
3. `community-config/skills/harness-curator/scripts/test.sh` — read third. 15 new assertions across three blocks: fixture dedup, dry-run-apply object-line shape, hermetic real-MemPalace round-trip. Pass count moves 38 → 53.
4. `assets/sample-frictions.json` — a 7th drawer carrying `opened_as: https://github.com/hcross/crewrig/issues/99` and a unique subcategory `stale-resolved-fixture` anchors the dedup assertions.

The `.claude/` and `.gemini/` mirrors under `{.claude,.gemini}/skills/harness-curator/` are generated by `scripts/build-components.sh` from the `community-config/` source.

## How to test this PR?

```bash
# Full harness curator test suite — should report 53 passing assertions
bash community-config/skills/harness-curator/scripts/test.sh

# SemVer guard — should exit 0 (script-only edits, no SKILL.md bump
# required for harness-curator)
bash scripts/check-skill-versions.sh

# Bundle parity — should exit 0 with "OK: All generated files match source."
bash scripts/build-components.sh --target all --check
```

## Detailed description (for agents)

### Production changes

**`curate.py` (+42 / -17)**
- `parse_friction()` now returns `Tuple[Optional[Dict], str]` where the string is `"ok"`, `"malformed"`, or `"resolved"`. A truthy `opened_as` value parsed off the FRICTION payload short-circuits to `(None, "resolved")`.
- `cluster_frictions()` signature widens from `(parsed, room, filed_at)` to `(parsed, room, filed_at, drawer_id)`; each friction in the returned list carries `_drawer_id`.
- `main()` threads `drawer_id` from the drawer dict into clustering and increments either `skipped_resolved` or `skipped_malformed` based on reason. The module docstring schema is updated to advertise `opened_as`.

**`apply.py` (+39 / -1)**
- Dry-run branch emits a second JSON line per cluster: `{"would_update_drawers": [...], "cluster_key": ...}` alongside the existing argv array line.
- Apply branch performs `from mempalace.mcp_server import tool_get_drawer, tool_update_drawer` **after** the dry-run early-return. After a successful `gh issue create`, the apply loop re-fetches each contributing drawer (`tool_get_drawer`), appends `opened_as: <url>` to the existing content, and writes via `tool_update_drawer`. Per-drawer write-back failures are logged to stderr; the cluster is not failed.

**`test.sh` (+128 / -7)** — 15 new assertions in three blocks (A: fixture dedup, B: `--dry-run-apply` object-line shape, C: hermetic real-MemPalace round-trip). Pass count 38 → 53.

**`assets/sample-frictions.json` (+6 / 0)** — a 7th drawer with `opened_as` and subcategory `stale-resolved-fixture` to anchor the new dedup tests.

### Design rationale

- **`opened_as:` placement**: appended as a `key: val` line inside the FRICTION payload. The existing parser tail loop at `curate.py:118-128` already absorbs arbitrary key/value lines, so no parser surgery was needed.
- **MCP import strategy**: Shape (ii) — defer the `mempalace.mcp_server` import to inside the apply write-back loop, gated by `not dry_run_apply`. Smaller blast radius than the alternative Shape (i) module-top `os.dup(1)`; keeps the dry-run path import-free.
- **Dry-run output**: emit BOTH the existing argv array line AND the new `would_update_drawers` object line. The existing `test.sh:170` grep `'^\['` matches only array lines, so prior assertions stay green.
- **Skip filter**: implemented inside `parse_friction()` (close to the schema). Returning `(None, "resolved")` lets the caller bookkeep `skipped_resolved` distinctly from `skipped_malformed`.
- **Re-fetch then update**: `tool_update_drawer` REPLACES content, so `apply.py` re-fetches via `tool_get_drawer` immediately before the write to avoid clobbering concurrent edits.

### Verified invariants

- SemVer guard exit 0; `harness-curator/SKILL.md` is unchanged so no bump is required. (5 OK entries from prior PRs in this session.)
- `skipped_resolved` is purely additive: a `grep` for `skipped_malformed` across the curator surface found only `test.sh:69` (asserts `"2"`) and `SKILL.md:77,99` (documentation). No consumer keys on a specific value.
- Regression dance: with the `curate.py` skip filter stashed, the suite exits 1 with 12 enumerated failures (valid_frictions 4→5, skipped_resolved 1→0, clusters_formed 3→4, clusters_above_threshold 2→3, `len(.clusters)` 2→3, resolved drawer leaks as severity:high singleton, dry-run-apply line counts inflated, real-MemPalace second-run dedup stats wrong, stamped drawer leaks). Post-restore: exit 0, all 53 pass.
- `scripts/build-components.sh --target all` exit 0; `--check` exit 0 with `OK: All generated files match source.` This PR observes the bundler-parity rail introduced by #70.

### Known limitations (V0.5 follow-up candidates, not blockers)

1. **Write-back partial failure**: `tool_update_drawer` failures are logged to stderr but the cluster is still reported as "Opened" in the final summary. The next curator run will re-open the issue. A `--strict-writeback` flag or an aggregate failure count in the run summary would tighten this. Acknowledged in design ("log + continue").
2. **Progress prints after lazy mempalace import**: once `from mempalace.mcp_server import ...` runs inside the apply loop, `sys.stdout` is hijacked (the same swap motivating #62). Subsequent `print()` for progress messages lands on stderr. This is a direct consequence of the Shape (ii) lazy-import choice — Shape (i) module-top dup would have avoided it at the cost of larger blast radius. Output is informational, not parsed.
3. **`_drawer_id` silently dropped**: in apply.py, frictions without `_drawer_id` are filtered out of `would_update_drawers` with no warning. Stdin is test-only territory; a stderr warn-on-omit would tighten the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)