### PR TITLE
🐛 Normalize file-URL canonicals in Curator apply (#63)

### DIFF
--- a/.claude/skills/harness-curator/scripts/apply.py
+++ b/.claude/skills/harness-curator/scripts/apply.py
@@ -22,6 +22,21 @@ import sys
 
 def _build_cmd(cluster: dict) -> list[str]:
     target = cluster["target_repo"]
+    # Defensive: a filer may set `canonical:` to a file URL
+    # (https://github.com/<o>/<r>/blob/<branch>/<path>) despite the
+    # schema requiring the bare repo form. Strip /blob/... or
+    # /tree/... so `gh --repo` receives a valid <owner>/<repo> slug.
+    # Schema contract: harness-report/SKILL.md → `canonical` field.
+    for sep in ("/blob/", "/tree/"):
+        if sep in target:
+            print(
+                f"  warn: target_repo '{target}' contains '{sep}'; "
+                "stripping to repo root. Filers should set canonical "
+                "to the repo URL, not a file URL.",
+                file=sys.stderr,
+            )
+            target = target.split(sep, 1)[0]
+            break
     title = cluster["title"]
     body = cluster["body"]
     labels = cluster.get("labels", ["harness-feedback"])

--- a/.claude/skills/harness-curator/scripts/test.sh
+++ b/.claude/skills/harness-curator/scripts/test.sh
@@ -259,6 +259,72 @@ echo "$EMPTY_OUT" | grep -q "No clusters above threshold; no issues to open." ||
 }
 echo "  PASS apply --dry-run-apply emits no-clusters notice"
 
+# --- Regression: defensive target_repo normalization (issue #63) ---------
+# A filer may set `canonical:` to a file URL (https://github.com/<o>/<r>/
+# blob/<branch>/<path>) or a tree URL (.../tree/<branch>/...) despite the
+# schema requiring the bare repo form. apply.py must strip /blob/... or
+# /tree/... so `gh --repo` receives a valid <owner>/<repo> slug, and warn
+# the maintainer on stderr. The clean-URL case must NOT emit the warning
+# (idempotence). Inline JSON because this exercises a malformed-input
+# shape that the existing sample-frictions fixture deliberately doesn't
+# cover.
+
+# Helper: build a minimal one-cluster payload around a given target_repo.
+# Strict-mode-safe printf form (single line, no heredoc indentation games).
+make_cluster_payload() {
+  local target="$1"
+  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}]}' "$target"
+}
+
+run_normalize_case() {
+  local label="$1" target="$2" tmp
+  tmp=$(mktemp -d -t crewrig-norm.XXXXXX)
+  set +e
+  make_cluster_payload "$target" | python3 "$APPLY" --dry-run-apply \
+    >"$tmp/out" 2>"$tmp/err"
+  local rc=$?
+  set -e
+  assert "$label exit code" "0" "$rc"
+  # argv is the first (and only) JSON array line on stdout.
+  local argv
+  argv=$(grep '^\[' "$tmp/out" | head -n1)
+  [ -n "$argv" ] || { echo "FAIL $label: no argv array line on stdout" >&2; cat "$tmp/out" >&2; exit 1; }
+  assert "$label argv --repo (slug only)" "hcross/crewrig" \
+    "$(echo "$argv" | jq -r '.[(index("--repo"))+1]')"
+  # Export tmpdir path via global so the caller can inspect stderr.
+  NORM_TMP="$tmp"
+}
+
+# Sub-case 1: /blob/<branch>/<path> form → stripped, warning emitted.
+run_normalize_case "norm.blob" \
+  "https://github.com/hcross/crewrig/blob/main/community-config/skills/architect/SKILL.md"
+if ! grep -q "stripping to repo root" "$NORM_TMP/err"; then
+  echo "FAIL norm.blob stderr missing 'stripping to repo root' warning" >&2
+  cat "$NORM_TMP/err" >&2
+  exit 1
+fi
+echo "  PASS norm.blob stderr contains 'stripping to repo root'"
+
+# Sub-case 2: /tree/<branch>/<path> form → stripped, warning emitted.
+run_normalize_case "norm.tree" \
+  "https://github.com/hcross/crewrig/tree/main/community-config"
+if ! grep -q "stripping to repo root" "$NORM_TMP/err"; then
+  echo "FAIL norm.tree stderr missing 'stripping to repo root' warning" >&2
+  cat "$NORM_TMP/err" >&2
+  exit 1
+fi
+echo "  PASS norm.tree stderr contains 'stripping to repo root'"
+
+# Sub-case 3: already-clean bare repo URL → SAME argv shape, NO warning.
+# Idempotence guard: the normalization block must not fire on valid input.
+run_normalize_case "norm.clean" "https://github.com/hcross/crewrig"
+if grep -q "stripping to repo root" "$NORM_TMP/err"; then
+  echo "FAIL norm.clean stderr unexpectedly contains 'stripping to repo root'" >&2
+  cat "$NORM_TMP/err" >&2
+  exit 1
+fi
+echo "  PASS norm.clean stderr does not contain 'stripping to repo root'"
+
 # --- Regression: real MemPalace path (no --from-stdin) -------------------
 # This section guards the curate-stdout-hijack bug (issue #62): when
 # curate.py reads from MemPalace, importing `mempalace.mcp_server` swaps

--- a/.claude/skills/harness-report/SKILL.md
+++ b/.claude/skills/harness-report/SKILL.md
@@ -7,7 +7,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 
@@ -98,8 +98,16 @@ Strongly encouraged:
 
 - `subcategory` — a free-form clustering anchor. Frictions sharing a
   `subcategory` get bundled into the same MR by the Curator.
-- `canonical` — the canonical URL of the offending component (from
-  its own `provenance.canonical` block when available).
+- `canonical` — the canonical **repo** URL of the offending
+  component's home, in the GitHub `https://github.com/<owner>/<repo>`
+  form (as set in the component's `provenance.canonical` block at
+  build time). NOT a file URL: the Curator's apply step routes the
+  issue via `gh issue create --repo <owner>/<repo>` by stripping the
+  `https://github.com/` prefix (see
+  `community-config/skills/harness-curator/scripts/apply.py:23-36`),
+  so a `/blob/<branch>/<path>` URL produces a malformed `--repo`
+  argument and the issue fails to land. Put the file path in
+  `evidence:` instead.
 - `severity` — `low` / `med` / `high`. Default `med`. Reserve `high`
   for blockers; it bypasses the cluster threshold and forces an MR.
 - `suggestion` — what you think would fix it. The Curator weighs

--- a/.gemini/skills/harness-curator/scripts/apply.py
+++ b/.gemini/skills/harness-curator/scripts/apply.py
@@ -22,6 +22,21 @@ import sys
 
 def _build_cmd(cluster: dict) -> list[str]:
     target = cluster["target_repo"]
+    # Defensive: a filer may set `canonical:` to a file URL
+    # (https://github.com/<o>/<r>/blob/<branch>/<path>) despite the
+    # schema requiring the bare repo form. Strip /blob/... or
+    # /tree/... so `gh --repo` receives a valid <owner>/<repo> slug.
+    # Schema contract: harness-report/SKILL.md → `canonical` field.
+    for sep in ("/blob/", "/tree/"):
+        if sep in target:
+            print(
+                f"  warn: target_repo '{target}' contains '{sep}'; "
+                "stripping to repo root. Filers should set canonical "
+                "to the repo URL, not a file URL.",
+                file=sys.stderr,
+            )
+            target = target.split(sep, 1)[0]
+            break
     title = cluster["title"]
     body = cluster["body"]
     labels = cluster.get("labels", ["harness-feedback"])

--- a/.gemini/skills/harness-curator/scripts/test.sh
+++ b/.gemini/skills/harness-curator/scripts/test.sh
@@ -259,6 +259,72 @@ echo "$EMPTY_OUT" | grep -q "No clusters above threshold; no issues to open." ||
 }
 echo "  PASS apply --dry-run-apply emits no-clusters notice"
 
+# --- Regression: defensive target_repo normalization (issue #63) ---------
+# A filer may set `canonical:` to a file URL (https://github.com/<o>/<r>/
+# blob/<branch>/<path>) or a tree URL (.../tree/<branch>/...) despite the
+# schema requiring the bare repo form. apply.py must strip /blob/... or
+# /tree/... so `gh --repo` receives a valid <owner>/<repo> slug, and warn
+# the maintainer on stderr. The clean-URL case must NOT emit the warning
+# (idempotence). Inline JSON because this exercises a malformed-input
+# shape that the existing sample-frictions fixture deliberately doesn't
+# cover.
+
+# Helper: build a minimal one-cluster payload around a given target_repo.
+# Strict-mode-safe printf form (single line, no heredoc indentation games).
+make_cluster_payload() {
+  local target="$1"
+  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}]}' "$target"
+}
+
+run_normalize_case() {
+  local label="$1" target="$2" tmp
+  tmp=$(mktemp -d -t crewrig-norm.XXXXXX)
+  set +e
+  make_cluster_payload "$target" | python3 "$APPLY" --dry-run-apply \
+    >"$tmp/out" 2>"$tmp/err"
+  local rc=$?
+  set -e
+  assert "$label exit code" "0" "$rc"
+  # argv is the first (and only) JSON array line on stdout.
+  local argv
+  argv=$(grep '^\[' "$tmp/out" | head -n1)
+  [ -n "$argv" ] || { echo "FAIL $label: no argv array line on stdout" >&2; cat "$tmp/out" >&2; exit 1; }
+  assert "$label argv --repo (slug only)" "hcross/crewrig" \
+    "$(echo "$argv" | jq -r '.[(index("--repo"))+1]')"
+  # Export tmpdir path via global so the caller can inspect stderr.
+  NORM_TMP="$tmp"
+}
+
+# Sub-case 1: /blob/<branch>/<path> form → stripped, warning emitted.
+run_normalize_case "norm.blob" \
+  "https://github.com/hcross/crewrig/blob/main/community-config/skills/architect/SKILL.md"
+if ! grep -q "stripping to repo root" "$NORM_TMP/err"; then
+  echo "FAIL norm.blob stderr missing 'stripping to repo root' warning" >&2
+  cat "$NORM_TMP/err" >&2
+  exit 1
+fi
+echo "  PASS norm.blob stderr contains 'stripping to repo root'"
+
+# Sub-case 2: /tree/<branch>/<path> form → stripped, warning emitted.
+run_normalize_case "norm.tree" \
+  "https://github.com/hcross/crewrig/tree/main/community-config"
+if ! grep -q "stripping to repo root" "$NORM_TMP/err"; then
+  echo "FAIL norm.tree stderr missing 'stripping to repo root' warning" >&2
+  cat "$NORM_TMP/err" >&2
+  exit 1
+fi
+echo "  PASS norm.tree stderr contains 'stripping to repo root'"
+
+# Sub-case 3: already-clean bare repo URL → SAME argv shape, NO warning.
+# Idempotence guard: the normalization block must not fire on valid input.
+run_normalize_case "norm.clean" "https://github.com/hcross/crewrig"
+if grep -q "stripping to repo root" "$NORM_TMP/err"; then
+  echo "FAIL norm.clean stderr unexpectedly contains 'stripping to repo root'" >&2
+  cat "$NORM_TMP/err" >&2
+  exit 1
+fi
+echo "  PASS norm.clean stderr does not contain 'stripping to repo root'"
+
 # --- Regression: real MemPalace path (no --from-stdin) -------------------
 # This section guards the curate-stdout-hijack bug (issue #62): when
 # curate.py reads from MemPalace, importing `mempalace.mcp_server` swaps

--- a/.gemini/skills/harness-report/SKILL.md
+++ b/.gemini/skills/harness-report/SKILL.md
@@ -4,7 +4,7 @@ description: "Tag a friction encountered during real work. Activate the moment a
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 
@@ -95,8 +95,16 @@ Strongly encouraged:
 
 - `subcategory` — a free-form clustering anchor. Frictions sharing a
   `subcategory` get bundled into the same MR by the Curator.
-- `canonical` — the canonical URL of the offending component (from
-  its own `provenance.canonical` block when available).
+- `canonical` — the canonical **repo** URL of the offending
+  component's home, in the GitHub `https://github.com/<owner>/<repo>`
+  form (as set in the component's `provenance.canonical` block at
+  build time). NOT a file URL: the Curator's apply step routes the
+  issue via `gh issue create --repo <owner>/<repo>` by stripping the
+  `https://github.com/` prefix (see
+  `community-config/skills/harness-curator/scripts/apply.py:23-36`),
+  so a `/blob/<branch>/<path>` URL produces a malformed `--repo`
+  argument and the issue fails to land. Put the file path in
+  `evidence:` instead.
 - `severity` — `low` / `med` / `high`. Default `med`. Reserve `high`
   for blockers; it bypasses the cluster threshold and forces an MR.
 - `suggestion` — what you think would fix it. The Curator weighs

--- a/community-config/skills/harness-curator/scripts/apply.py
+++ b/community-config/skills/harness-curator/scripts/apply.py
@@ -22,6 +22,21 @@ import sys
 
 def _build_cmd(cluster: dict) -> list[str]:
     target = cluster["target_repo"]
+    # Defensive: a filer may set `canonical:` to a file URL
+    # (https://github.com/<o>/<r>/blob/<branch>/<path>) despite the
+    # schema requiring the bare repo form. Strip /blob/... or
+    # /tree/... so `gh --repo` receives a valid <owner>/<repo> slug.
+    # Schema contract: harness-report/SKILL.md → `canonical` field.
+    for sep in ("/blob/", "/tree/"):
+        if sep in target:
+            print(
+                f"  warn: target_repo '{target}' contains '{sep}'; "
+                "stripping to repo root. Filers should set canonical "
+                "to the repo URL, not a file URL.",
+                file=sys.stderr,
+            )
+            target = target.split(sep, 1)[0]
+            break
     title = cluster["title"]
     body = cluster["body"]
     labels = cluster.get("labels", ["harness-feedback"])

--- a/community-config/skills/harness-curator/scripts/test.sh
+++ b/community-config/skills/harness-curator/scripts/test.sh
@@ -259,6 +259,72 @@ echo "$EMPTY_OUT" | grep -q "No clusters above threshold; no issues to open." ||
 }
 echo "  PASS apply --dry-run-apply emits no-clusters notice"
 
+# --- Regression: defensive target_repo normalization (issue #63) ---------
+# A filer may set `canonical:` to a file URL (https://github.com/<o>/<r>/
+# blob/<branch>/<path>) or a tree URL (.../tree/<branch>/...) despite the
+# schema requiring the bare repo form. apply.py must strip /blob/... or
+# /tree/... so `gh --repo` receives a valid <owner>/<repo> slug, and warn
+# the maintainer on stderr. The clean-URL case must NOT emit the warning
+# (idempotence). Inline JSON because this exercises a malformed-input
+# shape that the existing sample-frictions fixture deliberately doesn't
+# cover.
+
+# Helper: build a minimal one-cluster payload around a given target_repo.
+# Strict-mode-safe printf form (single line, no heredoc indentation games).
+make_cluster_payload() {
+  local target="$1"
+  printf '{"stats":{"total_drawers":1,"valid_frictions":1,"skipped_malformed":0,"skipped_resolved":0,"clusters_formed":1,"clusters_above_threshold":1,"clusters_parked":0,"routing_failures":0},"clusters":[{"cluster_key":"norm-probe","cluster_size":1,"target_repo":"%s","title":"normalization probe","body":"body","labels":["harness-feedback"],"frictions":[{"_drawer_id":"drw-norm-1"}]}]}' "$target"
+}
+
+run_normalize_case() {
+  local label="$1" target="$2" tmp
+  tmp=$(mktemp -d -t crewrig-norm.XXXXXX)
+  set +e
+  make_cluster_payload "$target" | python3 "$APPLY" --dry-run-apply \
+    >"$tmp/out" 2>"$tmp/err"
+  local rc=$?
+  set -e
+  assert "$label exit code" "0" "$rc"
+  # argv is the first (and only) JSON array line on stdout.
+  local argv
+  argv=$(grep '^\[' "$tmp/out" | head -n1)
+  [ -n "$argv" ] || { echo "FAIL $label: no argv array line on stdout" >&2; cat "$tmp/out" >&2; exit 1; }
+  assert "$label argv --repo (slug only)" "hcross/crewrig" \
+    "$(echo "$argv" | jq -r '.[(index("--repo"))+1]')"
+  # Export tmpdir path via global so the caller can inspect stderr.
+  NORM_TMP="$tmp"
+}
+
+# Sub-case 1: /blob/<branch>/<path> form → stripped, warning emitted.
+run_normalize_case "norm.blob" \
+  "https://github.com/hcross/crewrig/blob/main/community-config/skills/architect/SKILL.md"
+if ! grep -q "stripping to repo root" "$NORM_TMP/err"; then
+  echo "FAIL norm.blob stderr missing 'stripping to repo root' warning" >&2
+  cat "$NORM_TMP/err" >&2
+  exit 1
+fi
+echo "  PASS norm.blob stderr contains 'stripping to repo root'"
+
+# Sub-case 2: /tree/<branch>/<path> form → stripped, warning emitted.
+run_normalize_case "norm.tree" \
+  "https://github.com/hcross/crewrig/tree/main/community-config"
+if ! grep -q "stripping to repo root" "$NORM_TMP/err"; then
+  echo "FAIL norm.tree stderr missing 'stripping to repo root' warning" >&2
+  cat "$NORM_TMP/err" >&2
+  exit 1
+fi
+echo "  PASS norm.tree stderr contains 'stripping to repo root'"
+
+# Sub-case 3: already-clean bare repo URL → SAME argv shape, NO warning.
+# Idempotence guard: the normalization block must not fire on valid input.
+run_normalize_case "norm.clean" "https://github.com/hcross/crewrig"
+if grep -q "stripping to repo root" "$NORM_TMP/err"; then
+  echo "FAIL norm.clean stderr unexpectedly contains 'stripping to repo root'" >&2
+  cat "$NORM_TMP/err" >&2
+  exit 1
+fi
+echo "  PASS norm.clean stderr does not contain 'stripping to repo root'"
+
 # --- Regression: real MemPalace path (no --from-stdin) -------------------
 # This section guards the curate-stdout-hijack bug (issue #62): when
 # curate.py reads from MemPalace, importing `mempalace.mcp_server` swaps

--- a/community-config/skills/harness-report/SKILL.md
+++ b/community-config/skills/harness-report/SKILL.md
@@ -8,7 +8,7 @@ type: skill
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+  version: "1.0.1"
 claude:
   allowed-tools:
     - Read
@@ -102,8 +102,16 @@ Strongly encouraged:
 
 - `subcategory` — a free-form clustering anchor. Frictions sharing a
   `subcategory` get bundled into the same MR by the Curator.
-- `canonical` — the canonical URL of the offending component (from
-  its own `provenance.canonical` block when available).
+- `canonical` — the canonical **repo** URL of the offending
+  component's home, in the GitHub `https://github.com/<owner>/<repo>`
+  form (as set in the component's `provenance.canonical` block at
+  build time). NOT a file URL: the Curator's apply step routes the
+  issue via `gh issue create --repo <owner>/<repo>` by stripping the
+  `https://github.com/` prefix (see
+  `community-config/skills/harness-curator/scripts/apply.py:23-36`),
+  so a `/blob/<branch>/<path>` URL produces a malformed `--repo`
+  argument and the issue fails to land. Put the file path in
+  `evidence:` instead.
 - `severity` — `low` / `med` / `high`. Default `med`. Reserve `high`
   for blockers; it bypasses the cluster threshold and forces an MR.
 - `suggestion` — what you think would fix it. The Curator weighs

--- a/config/TOOLS.md
+++ b/config/TOOLS.md
@@ -503,11 +503,16 @@ suggestion: <free-form fix idea, optional but encouraged>
   above shows the canonical list form; a single inline value
   (`evidence: <path-or-url>` on one line) is also accepted as a
   one-entry list — useful when the friction has a single pointer.
-- `canonical` — when set, prefer the value of the offending component's
-  own `provenance.canonical` block. Hand-typing a different URL drifts
-  the friction away from the component the Curator should route the MR
-  against. If the offending component cannot be identified at tag time,
-  leave `canonical` empty and let `evidence:` carry the trail.
+- `canonical` — when set, prefer the value of the offending
+  component's own `provenance.canonical` block, which is the **repo**
+  URL (`https://github.com/<owner>/<repo>`). NOT a file URL: the
+  Curator routes the resulting issue via `gh issue create --repo
+  <owner>/<repo>`, so a `/blob/<branch>/<path>` URL produces a
+  malformed routing target. File paths and line numbers belong in
+  `evidence:`. Hand-typing a different repo URL drifts the friction
+  away from the component the Curator should route the MR against;
+  if the offending component cannot be identified at tag time, leave
+  `canonical` empty and let `evidence:` carry the trail.
 - `severity` — `high` is reserved for blockers (e.g. agent corrupted
   data, leaked a secret, or violated a stated guarantee). `low` is for
   papercuts. Default `med`.


### PR DESCRIPTION
Tighten the `canonical:` field contract in `harness-report` to demand a repo-root URL, and add a defensive normalization step in the Curator's `apply.py` so a file URL filed by mistake still routes to a real repo. Closes #63 (the friction was filed by claude-code itself earlier this session — a file-URL canonical reached `gh issue create` and 404'd at routing).

## How to read this PR?

1. `community-config/skills/harness-report/SKILL.md` (lines 105-114, version bump line 11 `1.0.0` → `1.0.1`) — the load-bearing wording change. The `canonical:` bullet now explicitly says **repo URL**, with an inline cross-reference to `community-config/skills/harness-curator/scripts/apply.py:23-36` explaining why (the Curator routes via `gh issue create --repo` and strips the `https://github.com/` prefix to derive the slug — a file URL leaves `/blob/<branch>/<path>` glued onto the slug).
2. `config/TOOLS.md` (lines 506-515) — the same contract mirrored, without the apply.py path citation (TOOLS.md is more general).
3. `community-config/skills/harness-curator/scripts/apply.py` (+15/-0) — the defensive strip in `_build_cmd()`. Architect's placement decision: stripping lives at the gh-slug boundary, not in `curate.py:pick_target_repo()` which returns the URL displayed in the issue body at `curate.py:332` ("Routed to `<target_repo>`"). Stripping there would mangle the human-facing audit trail of what the filer actually typed.
4. `community-config/skills/harness-curator/scripts/test.sh` (+66/-0) — 9 new assertions (3 sub-cases × 3) covering `norm.blob`, `norm.tree`, and `norm.clean` (idempotence). Pass count 54 → 63.
5. Generated bundles under `.claude/` and `.gemini/` mirror the three sources above per #70's component build contract.

## How to test this PR?

```bash
bash community-config/skills/harness-curator/scripts/test.sh
bash scripts/check-skill-versions.sh
bash scripts/build-components.sh --target all --check
```

Expected: all three exit `0`. The curator test prints 63 passes (was 54). The version-check guard catches the `harness-report` PATCH bump on `community-config/skills/harness-report/SKILL.md` line 11. The build-components `--check` confirms generated bundles match source.

Regression dance (per the developer brief): with the normalization loop stashed out, the suite exits `1` at the first new assertion — `norm.blob argv --repo (slug only)`, expected `hcross/crewrig`, got `hcross/crewrig/blob/main/community-config/skills/architect/SKILL.md`. Under `set -e` the suite aborts there; the blob-argv assertion is the canary. Post-restore, exit `0` with 63 passes.

## Detailed description (for agents)

### Doc tightening — `community-config/skills/harness-report/SKILL.md`

- Line 11: `version: "1.0.0"` → `version: "1.0.1"`. PATCH per `scripts/check-skill-versions.sh:80-82` (wording change, no contract break).
- Lines 105-114 (was 105-106 pre-edit): the `canonical:` bullet rewritten to be explicit about **repo URL**, not file URL form, with an inline cross-reference to `apply.py:23-36` explaining the failure mode. The load-bearing fact is one sentence: the Curator routes via `gh issue create --repo` and derives the slug by stripping `https://github.com/`; a file URL leaves path segments glued onto the slug.

### Doc tightening — `config/TOOLS.md`

- Lines 506-515 (was 506-510 pre-edit): same contract mirrored. The apply.py path citation is omitted (TOOLS.md is general-purpose). No version guard fires: `scripts/check-skill-versions.sh:44-46` globs only `community-config/skills/*/SKILL.md` and `community-config/agents/*/AGENT.md`.

### Defensive normalization — `community-config/skills/harness-curator/scripts/apply.py`

- `_build_cmd()` gains a `for sep in ("/blob/", "/tree/")` loop that strips file-URL segments from `target_repo`, prints a stderr warning, then `break`s. The bare-slug `replace("https://github.com/", "")` step still runs after.
- Architect's placement rationale: `_build_cmd()` is the boundary translating routing URL → gh-slug, so the stripping lives there. `pick_target_repo()` returns the URL displayed in the issue body at `curate.py:332` ("Routed to `<target_repo>`"); stripping in `curate.py` would mangle the human-facing audit trail of what the filer typed.
- Edge cases observed by the developer and flagged for review (NOT patched in this PR):
  - `https://github.com/owner/repo/pull/123` — not stripped (no `/blob/` or `/tree/`); would still produce a malformed `--repo`. Different mistake class from file-URL.
  - `https://gitlab.com/…` — host stripping only handles `github.com`; gitlab URLs already break upstream.
  - `git@github.com:owner/repo.git` — SSH form, untouched. Pre-existing limitation, not regressed.

### Test coverage — `community-config/skills/harness-curator/scripts/test.sh`

- 9 new assertions (3 sub-cases × 3):
  - `norm.blob`: malformed `/blob/main/<path>` target → argv `--repo` = `hcross/crewrig` (slug only); stderr contains `stripping to repo root`.
  - `norm.tree`: same shape for `/tree/<branch>/`.
  - `norm.clean` (idempotence): clean `https://github.com/owner/repo` → same argv; stderr does NOT contain the warning.
- The block is wedged AFTER existing `--dry-run-apply` assertions and BEFORE the hermetic real-MemPalace block (lines 261-321 post-edit).
- Pass count: 54 → 63.

### Bundle regeneration

- `.claude/skills/harness-curator/scripts/apply.py`, `.gemini/skills/harness-curator/scripts/apply.py`, plus the `test.sh` and `harness-report/SKILL.md` mirrors are regenerated from the `community-config/` source per #70's contract.
- `bash scripts/build-components.sh --target all` exits `0`; `--check` exits `0` with `OK: All generated files match source.`

### Flagged follow-ups (out of scope)

- Existing drawers with file-URL canonicals filed before this fix → the Curator's next pass will normalize them in `apply.py` automatically. Free side-benefit, no action.
- Forks pinning old `apply.py` lose the defensive strip — doc tightening still helps them.
- `CANONICAL_REPO` build substitution: if a fork sets it to a file URL, every friction filed against that fork carries a file URL by default. Hidden coupling, worth a follow-up issue.
- Auto-fix mode (#42): when it lands, must read the tightened schema.

### Provenance

The friction `harness-friction/prompt/canonical-field-ambiguity` was filed by claude-code earlier in this session. First manifestation: filing the pr-body-fabrication friction with `canonical: https://github.com/hcross/crewrig/blob/main/community-config/skills/pr-logbook/SKILL.md` (file URL), caught only at gh-invocation step during `/harness-curator`. Required a manual drawer update to fix routing. This is the 7th merge in the harness skill-quality chain (#57 → #62 → #61 → #67 → #70 → #69 → #69-fixup → #63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)