### PR TITLE
✨ Add setup-labels.sh bootstrap for Harness Curator (#64)

### DIFF
--- a/.claude/skills/harness-curator/SKILL.md
+++ b/.claude/skills/harness-curator/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 
@@ -137,17 +137,19 @@ and `severity:low|med|high`) **must be pre-created** on every repo
 that may receive curator output, before the first `--apply` run.
 A fork maintainer typically does this once at fork setup time.
 
-Recommended creation script (run once per target repo):
+Bootstrap the 9 labels via the bundled script (idempotent — safe to
+re-run after a label vocabulary change):
 
 ```bash
-gh label create harness-feedback --color FBCA04 --description "Auto-curated friction report"
-for room in tool prompt format behavior process; do
-  gh label create "room:$room" --color 0E8A16 --description "Friction category: $room"
-done
-for sev in low med high; do
-  gh label create "severity:$sev" --color "$(test "$sev" = high && echo D93F0B || test "$sev" = med && echo FBCA04 || echo C2E0C6)" --description "Friction severity: $sev"
-done
+bash scripts/setup-labels.sh --repo <owner/repo>
+# Or preview the plan without contacting GitHub:
+bash scripts/setup-labels.sh --repo <owner/repo> --dry-run
 ```
+
+The script uses `gh label create --force` per label, so it creates
+missing labels and updates the color / description of any that already
+exist. Omit `--repo` to target the repo resolved from the current
+working directory's git remote.
 
 If `--apply` fails on a missing label, the script surfaces it as a
 `failures:` entry in the run summary. The maintainer creates the

--- a/.claude/skills/harness-curator/scripts/setup-labels.sh
+++ b/.claude/skills/harness-curator/scripts/setup-labels.sh
@@ -37,7 +37,10 @@ REPO=""
 DRY_RUN=0
 
 usage() {
-  sed -n '2,30p' "$0" >&2
+  # Sentinel-based extraction: print the header doc-block (everything
+  # between line 2 and the first `set -euo pipefail` line, exclusive).
+  # This stays in sync with the header regardless of its length.
+  awk 'NR>1 && /^set -euo pipefail/ {exit} NR>1 {print}' "$0" >&2
 }
 
 while [ $# -gt 0 ]; do

--- a/.claude/skills/harness-curator/scripts/setup-labels.sh
+++ b/.claude/skills/harness-curator/scripts/setup-labels.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# setup-labels.sh — Bootstrap the GitHub labels used by the Harness Curator.
+#
+# `gh issue create --label <name>` fails if the label does not exist on
+# the target repo, so every fork that may receive curator output must
+# pre-create the 9 labels listed below before the first `--apply` run.
+# This script is the one-shot, idempotent bootstrap maintainers run once
+# per target repo (or any time the label vocabulary changes — re-runs
+# are safe, see `gh label create --force` semantics).
+#
+# Usage:
+#   bash scripts/setup-labels.sh [--repo <owner/repo>] [--dry-run]
+#
+# Options:
+#   --repo <owner/repo>  Target repo. Omit to let `gh` resolve from the
+#                        current working directory's git remote.
+#   --dry-run            Print the plan (one line per label) without
+#                        contacting GitHub. Exit 0 unless the args are
+#                        malformed.
+#
+# Exit codes:
+#   0   All 9 labels created or updated successfully (or dry-run plan
+#       printed).
+#   1   Usage error.
+#   2   One or more `gh label create` calls failed. Every label is
+#       attempted before exit — partial failure does not short-circuit.
+#
+# Idempotence: `gh label create --force` creates the label if absent,
+# otherwise updates its color and description in place. Re-running the
+# script after a label vocabulary change is the supported upgrade path.
+
+set -euo pipefail
+
+# --- Args ------------------------------------------------------------------
+
+REPO=""
+DRY_RUN=0
+
+usage() {
+  sed -n '2,30p' "$0" >&2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ $# -ge 2 ] || { echo "ERROR: --repo requires a value" >&2; usage; exit 1; }
+      REPO="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# --- Label vocabulary ------------------------------------------------------
+# Source of truth for the 9 labels the Curator emits. Format per row:
+#   name|color|description
+# Color values are 6-char hex (no leading #), per `gh label create -c`.
+# Keep this in sync with the labels documented in SKILL.md and produced
+# by curate.py / apply.py.
+
+LABELS=(
+  "harness-feedback|FBCA04|Auto-curated friction report"
+  "room:tool|0E8A16|Friction category: tool"
+  "room:prompt|0E8A16|Friction category: prompt"
+  "room:format|0E8A16|Friction category: format"
+  "room:behavior|0E8A16|Friction category: behavior"
+  "room:process|0E8A16|Friction category: process"
+  "severity:low|C2E0C6|Friction severity: low"
+  "severity:med|FBCA04|Friction severity: med"
+  "severity:high|D93F0B|Friction severity: high"
+)
+
+# --- Dry-run path ----------------------------------------------------------
+# Prints one line per label. Stable output shape — tester asserts on it.
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  for row in "${LABELS[@]}"; do
+    IFS='|' read -r name color desc <<<"$row"
+    echo "would create: $name (color=$color, description=$desc)"
+  done
+  exit 0
+fi
+
+# --- Apply path ------------------------------------------------------------
+# Per-label `gh label create --force`. Collect failures, attempt all 9
+# before exiting non-zero — surfacing the full failure set in one pass
+# beats forcing the maintainer to fix-and-rerun nine times.
+
+command -v gh >/dev/null 2>&1 || {
+  echo "ERROR: gh CLI is required but not found in PATH" >&2
+  exit 1
+}
+
+GH_ARGS=()
+if [ -n "$REPO" ]; then
+  GH_ARGS+=(--repo "$REPO")
+fi
+
+FAILURES=()
+
+for row in "${LABELS[@]}"; do
+  IFS='|' read -r name color desc <<<"$row"
+  if gh label create "$name" \
+       --color "$color" \
+       --description "$desc" \
+       --force \
+       "${GH_ARGS[@]}" >/dev/null 2>&1; then
+    echo "ok: $name"
+  else
+    echo "FAIL: $name" >&2
+    FAILURES+=("$name")
+  fi
+done
+
+if [ "${#FAILURES[@]}" -gt 0 ]; then
+  echo "" >&2
+  echo "ERROR: ${#FAILURES[@]} label(s) failed: ${FAILURES[*]}" >&2
+  echo "Re-run after resolving (check gh auth status and repo permissions)." >&2
+  exit 2
+fi
+
+echo ""
+echo "OK: all ${#LABELS[@]} labels bootstrapped${REPO:+ on $REPO}."

--- a/.claude/skills/harness-curator/scripts/test.sh
+++ b/.claude/skills/harness-curator/scripts/test.sh
@@ -325,6 +325,66 @@ if grep -q "stripping to repo root" "$NORM_TMP/err"; then
 fi
 echo "  PASS norm.clean stderr does not contain 'stripping to repo root'"
 
+# --- Smoke test: setup-labels.sh bootstrap (offline, --dry-run only) -----
+# Offline assertions on the dry-run plan — never contacts GitHub. Mirrors
+# the norm.* sub-case shape used in the apply.py normalization block
+# above. Exercises:
+#   (a) plan-line count + shape (proves the LABELS array is intact)
+#   (b) all three label families surface (harness-feedback / room:* /
+#       severity:*) so a partial vocabulary regression cannot pass
+#   (c) usage errors exit non-zero (unknown flag, missing --repo value)
+
+SETUP="$SKILL_DIR/scripts/setup-labels.sh"
+[ -f "$SETUP" ] || { echo "FAIL: setup-labels.sh missing: $SETUP" >&2; exit 1; }
+[ -x "$SETUP" ] || chmod +x "$SETUP"
+
+# setup.dry_run: --dry-run with a valid --repo exits 0 and emits a plan.
+set +e
+SETUP_OUT=$(bash "$SETUP" --repo hcross/crewrig --dry-run 2>/dev/null)
+SETUP_RC=$?
+set -e
+assert "setup.dry_run exit code" "0" "$SETUP_RC"
+
+# setup.plan_count: exactly 9 "would create:" lines (one per label).
+SETUP_PLAN_LINES=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: ')
+assert "setup.plan_count (9 labels)" "9" "$SETUP_PLAN_LINES"
+
+# setup.family.*: all three label families present. Separate assertions —
+# a regression that drops one family (e.g. truncated LABELS array) must
+# fail loudly, not be swallowed by a single composite check.
+SETUP_HAS_FEEDBACK=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: harness-feedback ')
+SETUP_HAS_ROOM=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: room:')
+SETUP_HAS_SEVERITY=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: severity:')
+[ "$SETUP_HAS_FEEDBACK" -ge 1 ] || { echo "FAIL setup.family.feedback: missing harness-feedback line" >&2; exit 1; }
+echo "  PASS setup.family.feedback"
+[ "$SETUP_HAS_ROOM"     -ge 1 ] || { echo "FAIL setup.family.room: missing room:* line(s)" >&2; exit 1; }
+echo "  PASS setup.family.room"
+[ "$SETUP_HAS_SEVERITY" -ge 1 ] || { echo "FAIL setup.family.severity: missing severity:* line(s)" >&2; exit 1; }
+echo "  PASS setup.family.severity"
+
+# setup.line_shape: every plan line carries color=<6hex> and a description.
+# `grep -vc` returns the count of NON-matching plan lines — must be zero.
+# `|| true` shields the count==0 case where grep exits 1.
+SETUP_BAD_SHAPE=$(printf '%s\n' "$SETUP_OUT" | grep '^would create: ' \
+  | grep -vcE ' \(color=[0-9A-Fa-f]{6}, description=.+\)$' || true)
+assert "setup.line_shape (color=<6hex>, description=...)" "0" "$SETUP_BAD_SHAPE"
+
+# setup.usage.bogus_flag: unknown argument → non-zero exit.
+set +e
+bash "$SETUP" --bogus >/dev/null 2>&1
+SETUP_BOGUS_RC=$?
+set -e
+[ "$SETUP_BOGUS_RC" -ne 0 ] || { echo "FAIL setup.usage.bogus_flag: expected non-zero exit, got $SETUP_BOGUS_RC" >&2; exit 1; }
+echo "  PASS setup.usage.bogus_flag (rc=$SETUP_BOGUS_RC)"
+
+# setup.usage.repo_no_value: --repo as final arg (no value) → non-zero exit.
+set +e
+bash "$SETUP" --repo >/dev/null 2>&1
+SETUP_NOVALUE_RC=$?
+set -e
+[ "$SETUP_NOVALUE_RC" -ne 0 ] || { echo "FAIL setup.usage.repo_no_value: expected non-zero exit, got $SETUP_NOVALUE_RC" >&2; exit 1; }
+echo "  PASS setup.usage.repo_no_value (rc=$SETUP_NOVALUE_RC)"
+
 # --- Regression: real MemPalace path (no --from-stdin) -------------------
 # This section guards the curate-stdout-hijack bug (issue #62): when
 # curate.py reads from MemPalace, importing `mempalace.mcp_server` swaps

--- a/.gemini/skills/harness-curator/SKILL.md
+++ b/.gemini/skills/harness-curator/SKILL.md
@@ -4,7 +4,7 @@ description: "Harness feedback-loop curator. Activate on demand to read friction
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 
@@ -131,17 +131,19 @@ and `severity:low|med|high`) **must be pre-created** on every repo
 that may receive curator output, before the first `--apply` run.
 A fork maintainer typically does this once at fork setup time.
 
-Recommended creation script (run once per target repo):
+Bootstrap the 9 labels via the bundled script (idempotent — safe to
+re-run after a label vocabulary change):
 
 ```bash
-gh label create harness-feedback --color FBCA04 --description "Auto-curated friction report"
-for room in tool prompt format behavior process; do
-  gh label create "room:$room" --color 0E8A16 --description "Friction category: $room"
-done
-for sev in low med high; do
-  gh label create "severity:$sev" --color "$(test "$sev" = high && echo D93F0B || test "$sev" = med && echo FBCA04 || echo C2E0C6)" --description "Friction severity: $sev"
-done
+bash scripts/setup-labels.sh --repo <owner/repo>
+# Or preview the plan without contacting GitHub:
+bash scripts/setup-labels.sh --repo <owner/repo> --dry-run
 ```
+
+The script uses `gh label create --force` per label, so it creates
+missing labels and updates the color / description of any that already
+exist. Omit `--repo` to target the repo resolved from the current
+working directory's git remote.
 
 If `--apply` fails on a missing label, the script surfaces it as a
 `failures:` entry in the run summary. The maintainer creates the

--- a/.gemini/skills/harness-curator/scripts/setup-labels.sh
+++ b/.gemini/skills/harness-curator/scripts/setup-labels.sh
@@ -37,7 +37,10 @@ REPO=""
 DRY_RUN=0
 
 usage() {
-  sed -n '2,30p' "$0" >&2
+  # Sentinel-based extraction: print the header doc-block (everything
+  # between line 2 and the first `set -euo pipefail` line, exclusive).
+  # This stays in sync with the header regardless of its length.
+  awk 'NR>1 && /^set -euo pipefail/ {exit} NR>1 {print}' "$0" >&2
 }
 
 while [ $# -gt 0 ]; do

--- a/.gemini/skills/harness-curator/scripts/setup-labels.sh
+++ b/.gemini/skills/harness-curator/scripts/setup-labels.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# setup-labels.sh — Bootstrap the GitHub labels used by the Harness Curator.
+#
+# `gh issue create --label <name>` fails if the label does not exist on
+# the target repo, so every fork that may receive curator output must
+# pre-create the 9 labels listed below before the first `--apply` run.
+# This script is the one-shot, idempotent bootstrap maintainers run once
+# per target repo (or any time the label vocabulary changes — re-runs
+# are safe, see `gh label create --force` semantics).
+#
+# Usage:
+#   bash scripts/setup-labels.sh [--repo <owner/repo>] [--dry-run]
+#
+# Options:
+#   --repo <owner/repo>  Target repo. Omit to let `gh` resolve from the
+#                        current working directory's git remote.
+#   --dry-run            Print the plan (one line per label) without
+#                        contacting GitHub. Exit 0 unless the args are
+#                        malformed.
+#
+# Exit codes:
+#   0   All 9 labels created or updated successfully (or dry-run plan
+#       printed).
+#   1   Usage error.
+#   2   One or more `gh label create` calls failed. Every label is
+#       attempted before exit — partial failure does not short-circuit.
+#
+# Idempotence: `gh label create --force` creates the label if absent,
+# otherwise updates its color and description in place. Re-running the
+# script after a label vocabulary change is the supported upgrade path.
+
+set -euo pipefail
+
+# --- Args ------------------------------------------------------------------
+
+REPO=""
+DRY_RUN=0
+
+usage() {
+  sed -n '2,30p' "$0" >&2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ $# -ge 2 ] || { echo "ERROR: --repo requires a value" >&2; usage; exit 1; }
+      REPO="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# --- Label vocabulary ------------------------------------------------------
+# Source of truth for the 9 labels the Curator emits. Format per row:
+#   name|color|description
+# Color values are 6-char hex (no leading #), per `gh label create -c`.
+# Keep this in sync with the labels documented in SKILL.md and produced
+# by curate.py / apply.py.
+
+LABELS=(
+  "harness-feedback|FBCA04|Auto-curated friction report"
+  "room:tool|0E8A16|Friction category: tool"
+  "room:prompt|0E8A16|Friction category: prompt"
+  "room:format|0E8A16|Friction category: format"
+  "room:behavior|0E8A16|Friction category: behavior"
+  "room:process|0E8A16|Friction category: process"
+  "severity:low|C2E0C6|Friction severity: low"
+  "severity:med|FBCA04|Friction severity: med"
+  "severity:high|D93F0B|Friction severity: high"
+)
+
+# --- Dry-run path ----------------------------------------------------------
+# Prints one line per label. Stable output shape — tester asserts on it.
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  for row in "${LABELS[@]}"; do
+    IFS='|' read -r name color desc <<<"$row"
+    echo "would create: $name (color=$color, description=$desc)"
+  done
+  exit 0
+fi
+
+# --- Apply path ------------------------------------------------------------
+# Per-label `gh label create --force`. Collect failures, attempt all 9
+# before exiting non-zero — surfacing the full failure set in one pass
+# beats forcing the maintainer to fix-and-rerun nine times.
+
+command -v gh >/dev/null 2>&1 || {
+  echo "ERROR: gh CLI is required but not found in PATH" >&2
+  exit 1
+}
+
+GH_ARGS=()
+if [ -n "$REPO" ]; then
+  GH_ARGS+=(--repo "$REPO")
+fi
+
+FAILURES=()
+
+for row in "${LABELS[@]}"; do
+  IFS='|' read -r name color desc <<<"$row"
+  if gh label create "$name" \
+       --color "$color" \
+       --description "$desc" \
+       --force \
+       "${GH_ARGS[@]}" >/dev/null 2>&1; then
+    echo "ok: $name"
+  else
+    echo "FAIL: $name" >&2
+    FAILURES+=("$name")
+  fi
+done
+
+if [ "${#FAILURES[@]}" -gt 0 ]; then
+  echo "" >&2
+  echo "ERROR: ${#FAILURES[@]} label(s) failed: ${FAILURES[*]}" >&2
+  echo "Re-run after resolving (check gh auth status and repo permissions)." >&2
+  exit 2
+fi
+
+echo ""
+echo "OK: all ${#LABELS[@]} labels bootstrapped${REPO:+ on $REPO}."

--- a/.gemini/skills/harness-curator/scripts/test.sh
+++ b/.gemini/skills/harness-curator/scripts/test.sh
@@ -325,6 +325,66 @@ if grep -q "stripping to repo root" "$NORM_TMP/err"; then
 fi
 echo "  PASS norm.clean stderr does not contain 'stripping to repo root'"
 
+# --- Smoke test: setup-labels.sh bootstrap (offline, --dry-run only) -----
+# Offline assertions on the dry-run plan — never contacts GitHub. Mirrors
+# the norm.* sub-case shape used in the apply.py normalization block
+# above. Exercises:
+#   (a) plan-line count + shape (proves the LABELS array is intact)
+#   (b) all three label families surface (harness-feedback / room:* /
+#       severity:*) so a partial vocabulary regression cannot pass
+#   (c) usage errors exit non-zero (unknown flag, missing --repo value)
+
+SETUP="$SKILL_DIR/scripts/setup-labels.sh"
+[ -f "$SETUP" ] || { echo "FAIL: setup-labels.sh missing: $SETUP" >&2; exit 1; }
+[ -x "$SETUP" ] || chmod +x "$SETUP"
+
+# setup.dry_run: --dry-run with a valid --repo exits 0 and emits a plan.
+set +e
+SETUP_OUT=$(bash "$SETUP" --repo hcross/crewrig --dry-run 2>/dev/null)
+SETUP_RC=$?
+set -e
+assert "setup.dry_run exit code" "0" "$SETUP_RC"
+
+# setup.plan_count: exactly 9 "would create:" lines (one per label).
+SETUP_PLAN_LINES=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: ')
+assert "setup.plan_count (9 labels)" "9" "$SETUP_PLAN_LINES"
+
+# setup.family.*: all three label families present. Separate assertions —
+# a regression that drops one family (e.g. truncated LABELS array) must
+# fail loudly, not be swallowed by a single composite check.
+SETUP_HAS_FEEDBACK=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: harness-feedback ')
+SETUP_HAS_ROOM=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: room:')
+SETUP_HAS_SEVERITY=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: severity:')
+[ "$SETUP_HAS_FEEDBACK" -ge 1 ] || { echo "FAIL setup.family.feedback: missing harness-feedback line" >&2; exit 1; }
+echo "  PASS setup.family.feedback"
+[ "$SETUP_HAS_ROOM"     -ge 1 ] || { echo "FAIL setup.family.room: missing room:* line(s)" >&2; exit 1; }
+echo "  PASS setup.family.room"
+[ "$SETUP_HAS_SEVERITY" -ge 1 ] || { echo "FAIL setup.family.severity: missing severity:* line(s)" >&2; exit 1; }
+echo "  PASS setup.family.severity"
+
+# setup.line_shape: every plan line carries color=<6hex> and a description.
+# `grep -vc` returns the count of NON-matching plan lines — must be zero.
+# `|| true` shields the count==0 case where grep exits 1.
+SETUP_BAD_SHAPE=$(printf '%s\n' "$SETUP_OUT" | grep '^would create: ' \
+  | grep -vcE ' \(color=[0-9A-Fa-f]{6}, description=.+\)$' || true)
+assert "setup.line_shape (color=<6hex>, description=...)" "0" "$SETUP_BAD_SHAPE"
+
+# setup.usage.bogus_flag: unknown argument → non-zero exit.
+set +e
+bash "$SETUP" --bogus >/dev/null 2>&1
+SETUP_BOGUS_RC=$?
+set -e
+[ "$SETUP_BOGUS_RC" -ne 0 ] || { echo "FAIL setup.usage.bogus_flag: expected non-zero exit, got $SETUP_BOGUS_RC" >&2; exit 1; }
+echo "  PASS setup.usage.bogus_flag (rc=$SETUP_BOGUS_RC)"
+
+# setup.usage.repo_no_value: --repo as final arg (no value) → non-zero exit.
+set +e
+bash "$SETUP" --repo >/dev/null 2>&1
+SETUP_NOVALUE_RC=$?
+set -e
+[ "$SETUP_NOVALUE_RC" -ne 0 ] || { echo "FAIL setup.usage.repo_no_value: expected non-zero exit, got $SETUP_NOVALUE_RC" >&2; exit 1; }
+echo "  PASS setup.usage.repo_no_value (rc=$SETUP_NOVALUE_RC)"
+
 # --- Regression: real MemPalace path (no --from-stdin) -------------------
 # This section guards the curate-stdout-hijack bug (issue #62): when
 # curate.py reads from MemPalace, importing `mempalace.mcp_server` swaps

--- a/community-config/skills/harness-curator/SKILL.md
+++ b/community-config/skills/harness-curator/SKILL.md
@@ -6,11 +6,11 @@ description: "Harness feedback-loop curator. Activate on demand to read
   declared in components' provenance blocks. The fix MR lands later
   (human-authored or via the auto-fix mode tracked in #42)."
 type: skill
-compatibility: Requires bash, jq, and the mempalace Python package (pipx install 'mempalace>=3.3.3,<3.4').
+compatibility: Requires bash, jq, the gh CLI (used by setup-labels.sh and --apply), and the mempalace Python package (pipx install 'mempalace>=3.3.3,<3.4').
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+  version: "1.1.0"
 claude:
   allowed-tools:
     - Read
@@ -143,17 +143,19 @@ and `severity:low|med|high`) **must be pre-created** on every repo
 that may receive curator output, before the first `--apply` run.
 A fork maintainer typically does this once at fork setup time.
 
-Recommended creation script (run once per target repo):
+Bootstrap the 9 labels via the bundled script (idempotent — safe to
+re-run after a label vocabulary change):
 
 ```bash
-gh label create harness-feedback --color FBCA04 --description "Auto-curated friction report"
-for room in tool prompt format behavior process; do
-  gh label create "room:$room" --color 0E8A16 --description "Friction category: $room"
-done
-for sev in low med high; do
-  gh label create "severity:$sev" --color "$(test "$sev" = high && echo D93F0B || test "$sev" = med && echo FBCA04 || echo C2E0C6)" --description "Friction severity: $sev"
-done
+bash scripts/setup-labels.sh --repo <owner/repo>
+# Or preview the plan without contacting GitHub:
+bash scripts/setup-labels.sh --repo <owner/repo> --dry-run
 ```
+
+The script uses `gh label create --force` per label, so it creates
+missing labels and updates the color / description of any that already
+exist. Omit `--repo` to target the repo resolved from the current
+working directory's git remote.
 
 If `--apply` fails on a missing label, the script surfaces it as a
 `failures:` entry in the run summary. The maintainer creates the

--- a/community-config/skills/harness-curator/scripts/setup-labels.sh
+++ b/community-config/skills/harness-curator/scripts/setup-labels.sh
@@ -37,7 +37,10 @@ REPO=""
 DRY_RUN=0
 
 usage() {
-  sed -n '2,30p' "$0" >&2
+  # Sentinel-based extraction: print the header doc-block (everything
+  # between line 2 and the first `set -euo pipefail` line, exclusive).
+  # This stays in sync with the header regardless of its length.
+  awk 'NR>1 && /^set -euo pipefail/ {exit} NR>1 {print}' "$0" >&2
 }
 
 while [ $# -gt 0 ]; do

--- a/community-config/skills/harness-curator/scripts/setup-labels.sh
+++ b/community-config/skills/harness-curator/scripts/setup-labels.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# setup-labels.sh — Bootstrap the GitHub labels used by the Harness Curator.
+#
+# `gh issue create --label <name>` fails if the label does not exist on
+# the target repo, so every fork that may receive curator output must
+# pre-create the 9 labels listed below before the first `--apply` run.
+# This script is the one-shot, idempotent bootstrap maintainers run once
+# per target repo (or any time the label vocabulary changes — re-runs
+# are safe, see `gh label create --force` semantics).
+#
+# Usage:
+#   bash scripts/setup-labels.sh [--repo <owner/repo>] [--dry-run]
+#
+# Options:
+#   --repo <owner/repo>  Target repo. Omit to let `gh` resolve from the
+#                        current working directory's git remote.
+#   --dry-run            Print the plan (one line per label) without
+#                        contacting GitHub. Exit 0 unless the args are
+#                        malformed.
+#
+# Exit codes:
+#   0   All 9 labels created or updated successfully (or dry-run plan
+#       printed).
+#   1   Usage error.
+#   2   One or more `gh label create` calls failed. Every label is
+#       attempted before exit — partial failure does not short-circuit.
+#
+# Idempotence: `gh label create --force` creates the label if absent,
+# otherwise updates its color and description in place. Re-running the
+# script after a label vocabulary change is the supported upgrade path.
+
+set -euo pipefail
+
+# --- Args ------------------------------------------------------------------
+
+REPO=""
+DRY_RUN=0
+
+usage() {
+  sed -n '2,30p' "$0" >&2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)
+      [ $# -ge 2 ] || { echo "ERROR: --repo requires a value" >&2; usage; exit 1; }
+      REPO="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# --- Label vocabulary ------------------------------------------------------
+# Source of truth for the 9 labels the Curator emits. Format per row:
+#   name|color|description
+# Color values are 6-char hex (no leading #), per `gh label create -c`.
+# Keep this in sync with the labels documented in SKILL.md and produced
+# by curate.py / apply.py.
+
+LABELS=(
+  "harness-feedback|FBCA04|Auto-curated friction report"
+  "room:tool|0E8A16|Friction category: tool"
+  "room:prompt|0E8A16|Friction category: prompt"
+  "room:format|0E8A16|Friction category: format"
+  "room:behavior|0E8A16|Friction category: behavior"
+  "room:process|0E8A16|Friction category: process"
+  "severity:low|C2E0C6|Friction severity: low"
+  "severity:med|FBCA04|Friction severity: med"
+  "severity:high|D93F0B|Friction severity: high"
+)
+
+# --- Dry-run path ----------------------------------------------------------
+# Prints one line per label. Stable output shape — tester asserts on it.
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  for row in "${LABELS[@]}"; do
+    IFS='|' read -r name color desc <<<"$row"
+    echo "would create: $name (color=$color, description=$desc)"
+  done
+  exit 0
+fi
+
+# --- Apply path ------------------------------------------------------------
+# Per-label `gh label create --force`. Collect failures, attempt all 9
+# before exiting non-zero — surfacing the full failure set in one pass
+# beats forcing the maintainer to fix-and-rerun nine times.
+
+command -v gh >/dev/null 2>&1 || {
+  echo "ERROR: gh CLI is required but not found in PATH" >&2
+  exit 1
+}
+
+GH_ARGS=()
+if [ -n "$REPO" ]; then
+  GH_ARGS+=(--repo "$REPO")
+fi
+
+FAILURES=()
+
+for row in "${LABELS[@]}"; do
+  IFS='|' read -r name color desc <<<"$row"
+  if gh label create "$name" \
+       --color "$color" \
+       --description "$desc" \
+       --force \
+       "${GH_ARGS[@]}" >/dev/null 2>&1; then
+    echo "ok: $name"
+  else
+    echo "FAIL: $name" >&2
+    FAILURES+=("$name")
+  fi
+done
+
+if [ "${#FAILURES[@]}" -gt 0 ]; then
+  echo "" >&2
+  echo "ERROR: ${#FAILURES[@]} label(s) failed: ${FAILURES[*]}" >&2
+  echo "Re-run after resolving (check gh auth status and repo permissions)." >&2
+  exit 2
+fi
+
+echo ""
+echo "OK: all ${#LABELS[@]} labels bootstrapped${REPO:+ on $REPO}."

--- a/community-config/skills/harness-curator/scripts/test.sh
+++ b/community-config/skills/harness-curator/scripts/test.sh
@@ -325,6 +325,66 @@ if grep -q "stripping to repo root" "$NORM_TMP/err"; then
 fi
 echo "  PASS norm.clean stderr does not contain 'stripping to repo root'"
 
+# --- Smoke test: setup-labels.sh bootstrap (offline, --dry-run only) -----
+# Offline assertions on the dry-run plan — never contacts GitHub. Mirrors
+# the norm.* sub-case shape used in the apply.py normalization block
+# above. Exercises:
+#   (a) plan-line count + shape (proves the LABELS array is intact)
+#   (b) all three label families surface (harness-feedback / room:* /
+#       severity:*) so a partial vocabulary regression cannot pass
+#   (c) usage errors exit non-zero (unknown flag, missing --repo value)
+
+SETUP="$SKILL_DIR/scripts/setup-labels.sh"
+[ -f "$SETUP" ] || { echo "FAIL: setup-labels.sh missing: $SETUP" >&2; exit 1; }
+[ -x "$SETUP" ] || chmod +x "$SETUP"
+
+# setup.dry_run: --dry-run with a valid --repo exits 0 and emits a plan.
+set +e
+SETUP_OUT=$(bash "$SETUP" --repo hcross/crewrig --dry-run 2>/dev/null)
+SETUP_RC=$?
+set -e
+assert "setup.dry_run exit code" "0" "$SETUP_RC"
+
+# setup.plan_count: exactly 9 "would create:" lines (one per label).
+SETUP_PLAN_LINES=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: ')
+assert "setup.plan_count (9 labels)" "9" "$SETUP_PLAN_LINES"
+
+# setup.family.*: all three label families present. Separate assertions —
+# a regression that drops one family (e.g. truncated LABELS array) must
+# fail loudly, not be swallowed by a single composite check.
+SETUP_HAS_FEEDBACK=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: harness-feedback ')
+SETUP_HAS_ROOM=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: room:')
+SETUP_HAS_SEVERITY=$(printf '%s\n' "$SETUP_OUT" | grep -c '^would create: severity:')
+[ "$SETUP_HAS_FEEDBACK" -ge 1 ] || { echo "FAIL setup.family.feedback: missing harness-feedback line" >&2; exit 1; }
+echo "  PASS setup.family.feedback"
+[ "$SETUP_HAS_ROOM"     -ge 1 ] || { echo "FAIL setup.family.room: missing room:* line(s)" >&2; exit 1; }
+echo "  PASS setup.family.room"
+[ "$SETUP_HAS_SEVERITY" -ge 1 ] || { echo "FAIL setup.family.severity: missing severity:* line(s)" >&2; exit 1; }
+echo "  PASS setup.family.severity"
+
+# setup.line_shape: every plan line carries color=<6hex> and a description.
+# `grep -vc` returns the count of NON-matching plan lines — must be zero.
+# `|| true` shields the count==0 case where grep exits 1.
+SETUP_BAD_SHAPE=$(printf '%s\n' "$SETUP_OUT" | grep '^would create: ' \
+  | grep -vcE ' \(color=[0-9A-Fa-f]{6}, description=.+\)$' || true)
+assert "setup.line_shape (color=<6hex>, description=...)" "0" "$SETUP_BAD_SHAPE"
+
+# setup.usage.bogus_flag: unknown argument → non-zero exit.
+set +e
+bash "$SETUP" --bogus >/dev/null 2>&1
+SETUP_BOGUS_RC=$?
+set -e
+[ "$SETUP_BOGUS_RC" -ne 0 ] || { echo "FAIL setup.usage.bogus_flag: expected non-zero exit, got $SETUP_BOGUS_RC" >&2; exit 1; }
+echo "  PASS setup.usage.bogus_flag (rc=$SETUP_BOGUS_RC)"
+
+# setup.usage.repo_no_value: --repo as final arg (no value) → non-zero exit.
+set +e
+bash "$SETUP" --repo >/dev/null 2>&1
+SETUP_NOVALUE_RC=$?
+set -e
+[ "$SETUP_NOVALUE_RC" -ne 0 ] || { echo "FAIL setup.usage.repo_no_value: expected non-zero exit, got $SETUP_NOVALUE_RC" >&2; exit 1; }
+echo "  PASS setup.usage.repo_no_value (rc=$SETUP_NOVALUE_RC)"
+
 # --- Regression: real MemPalace path (no --from-stdin) -------------------
 # This section guards the curate-stdout-hijack bug (issue #62): when
 # curate.py reads from MemPalace, importing `mempalace.mcp_server` swaps


### PR DESCRIPTION
The Harness Curator's `--apply` mode fails when target-repo labels are missing, and the prior documentation forced maintainers to copy-paste a `gh label create` snippet that would error on re-run. This PR ships `setup-labels.sh` — an idempotent, dry-run-capable bootstrap script — and rewires SKILL.md to reference it.

## How to read this PR?

1. `community-config/skills/harness-curator/scripts/setup-labels.sh` (new, +135 lines) — the bootstrap. Start at the header doc-block, then the `LABELS` array (single source of truth, 9 rows), then the two execution paths (`--dry-run` vs apply).
2. `community-config/skills/harness-curator/SKILL.md` — three coordinated edits: line 9 compatibility note appends the gh CLI dependency; line 13 `version: "1.0.0"` → `"1.1.0"` (MINOR bump — additive feature surface); lines 143-160 replace the inline copy-paste snippet with a 3-line callout pointing at the script.
3. `community-config/skills/harness-curator/scripts/test.sh` — 8 new assertions wedged between the `norm.clean` block and the `Regression: real MemPalace path` section so they always run, never gated by the mempalace SKIP. Offline-only; never contacts GitHub.

## How to test this PR?

```bash
# Smoke the script directly
bash community-config/skills/harness-curator/scripts/setup-labels.sh --dry-run
bash community-config/skills/harness-curator/scripts/setup-labels.sh --bogus      # expect exit 1
bash community-config/skills/harness-curator/scripts/setup-labels.sh --repo       # expect exit 1 (no value)

# Run the harness-curator test battery
bash community-config/skills/harness-curator/scripts/test.sh
# Expected: 71 PASS, exit 0 (was 63 PASS pre-PR; +8 new assertions)

# Confirm SKILL.md version bookkeeping
bash scripts/check-skill-versions.sh
# Expected: exit 0
```

## Detailed description (for agents)

### Design rationale (architect)

- **One script, one source of truth.** The 9 labels (`harness-feedback`, `room:{tool,prompt,format,behavior,process}`, `severity:{low,med,high}`) live as a single `LABELS=(name|color|description …)` array in `setup-labels.sh`. The pipe-delimited row format keeps inline editing cheap and is parsed via `IFS='|' read`. Keeping the vocabulary in one place means SKILL.md, `curate.py`, `apply.py`, and the bootstrap stay in lockstep.
- **`gh label create --force` per row.** `gh label create --help` documents `--force` as *"Update the label color and description if label already exists"* — that single flag turns the call into a create-or-update, eliminating the re-run footgun of the previous copy-paste snippet (which would fail on already-existing labels).
- **Attempt all 9 before exit.** Failure collection accumulates into a `FAILURES` array; the script only exits 2 *after* the full pass. Surfacing the full failure set in one shot beats forcing the maintainer to fix-and-rerun nine times. Usage errors exit 1; success exits 0.
- **`--dry-run` with a stable output shape.** Emits exactly one `would create: <name> (color=<6-hex>, description=<…>)` line per label. The shape is deliberately fixed so the test harness can assert on it without invoking GitHub.
- **MINOR (not PATCH) version bump.** The change adds a feature surface (a new script invokable by maintainers), not just a fix — `1.0.0 → 1.1.0` per the skill's semver contract.
- **Compatibility note widened.** The skill already required `gh` transitively via `--apply`; SKILL.md line 9 now states this explicitly: `the gh CLI (used by setup-labels.sh and --apply)`.

### Regression dance (tester, two canaries)

The 8 new assertions in `test.sh` were validated by canary regression:

- **Canary 1 — vocabulary drift.** Three `severity:*` rows commented out of the `LABELS` array. Test halts at `FAIL setup.plan_count — expected '9', got '6'`. Restoring the rows returns the suite to green.
- **Canary 2 — validation drift.** The `*) ... exit 1` arm of the arg parser swapped for `*) exit 0`. Test halts at `FAIL setup.usage.bogus_flag — expected non-zero exit, got 0`. Restoring the arm returns the suite to green.

Both canaries fire on a *new* assertion at the expected point, confirming each new check is load-bearing rather than co-passing on a pre-existing line. Final clean run: 71 PASS, exit 0 (was 63 → +8).

Coverage map of the 8 assertions:

| Assertion | Subject |
|---|---|
| `setup.dry_run exit code` | `--repo hcross/crewrig --dry-run` exits 0 |
| `setup.plan_count (9 labels)` | exactly 9 `^would create: ` lines |
| `setup.family.feedback` / `.room` / `.severity` | each family contributes ≥1 plan line |
| `setup.line_shape (color=<6hex>, description=...)` | 0 non-conforming plan lines |
| `setup.usage.bogus_flag (rc=1)` | unknown flag exits non-zero |
| `setup.usage.repo_no_value (rc=1)` | `--repo` with no value exits non-zero |

Pattern mirrors the existing `norm.blob` / `norm.tree` / `norm.clean` blocks.

### Verify gates (developer)

- `bash community-config/skills/harness-curator/scripts/test.sh` → 71 PASS, exit 0 (post-tester).
- `bash scripts/check-skill-versions.sh` → exit 0; reports 7 changed sources including `harness-curator/SKILL.md` OK (base-ref artefact accumulates prior PRs' bumps — same pattern as previous PRs in this chain).
- Manual smoke: `--dry-run` prints 9 plan lines; `--bogus` rejected exit 1; `--repo` without value rejected exit 1.

### Bundle regeneration

Per the `#70` rule on developer's `### 3. Prove it locally`, `.gemini/skills/harness-curator/...` and `.claude/skills/harness-curator/...` mirrors were regenerated via `bash scripts/build-components.sh --target all`. `--check` exits 0 with `OK: All generated files match source.`

### Chain context

This is the 8th consecutive merge in the harness skill-quality run started earlier in the session (#57 → #62 → #61 → #67 → #70 → #69 → #69-fixup → #63 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)