### PR TITLE
📝 Require call-graph context in architect sub-agent briefs (#68)

### DIFF
--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.2"
+  version: "1.0.3"
 ---
 
 
@@ -94,6 +94,27 @@ neither — do not over-document.
 ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
+
+### 5. Briefing sub-agents (call-graph context)
+
+When delegating a focused task (tester, security, doc-writer, etc.) to a
+sub-agent, the brief MUST include the **call-graph context** of any file
+the sub-agent will read or evaluate — at minimum:
+
+- The **entry point(s)** that invoke the target file in production paths.
+- **Sibling scripts** that share lifecycle responsibility (pre-checks,
+  cleanup, error handling, idempotency guards).
+- Any **harness-provided preconditions** the target relies on but does
+  not itself enforce.
+
+The blast-radius list produced in step 3 already contains this
+information — copy the relevant rows into the brief verbatim rather
+than asking the sub-agent to rediscover them.
+
+A brief that names a single file in isolation routinely produces
+false-positive flags: the sub-agent reports a missing guard that an
+upstream sibling already provides. Treat this as a brief defect, not
+a sub-agent defect.
 
 ## Grounding discipline
 

--- a/.gemini/skills/architect/SKILL.md
+++ b/.gemini/skills/architect/SKILL.md
@@ -4,7 +4,7 @@ description: "Design and architecture skill for ADRs, RFCs, design reviews, and 
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.2"
+  version: "1.0.3"
 ---
 
 
@@ -88,6 +88,27 @@ neither — do not over-document.
 ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
+
+### 5. Briefing sub-agents (call-graph context)
+
+When delegating a focused task (tester, security, doc-writer, etc.) to a
+sub-agent, the brief MUST include the **call-graph context** of any file
+the sub-agent will read or evaluate — at minimum:
+
+- The **entry point(s)** that invoke the target file in production paths.
+- **Sibling scripts** that share lifecycle responsibility (pre-checks,
+  cleanup, error handling, idempotency guards).
+- Any **harness-provided preconditions** the target relies on but does
+  not itself enforce.
+
+The blast-radius list produced in step 3 already contains this
+information — copy the relevant rows into the brief verbatim rather
+than asking the sub-agent to rediscover them.
+
+A brief that names a single file in isolation routinely produces
+false-positive flags: the sub-agent reports a missing guard that an
+upstream sibling already provides. Treat this as a brief defect, not
+a sub-agent defect.
 
 ## Grounding discipline
 

--- a/community-config/skills/architect/SKILL.md
+++ b/community-config/skills/architect/SKILL.md
@@ -8,7 +8,7 @@ type: skill
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.2"
+  version: "1.0.3"
 claude:
   allowed-tools:
     - Read
@@ -98,6 +98,27 @@ neither — do not over-document.
 ADRs follow the standard sections: Context, Decision, Status, Consequences.
 Keep each section under 10 lines. ADRs that need a 2-page Context have
 not been thought through yet.
+
+### 5. Briefing sub-agents (call-graph context)
+
+When delegating a focused task (tester, security, doc-writer, etc.) to a
+sub-agent, the brief MUST include the **call-graph context** of any file
+the sub-agent will read or evaluate — at minimum:
+
+- The **entry point(s)** that invoke the target file in production paths.
+- **Sibling scripts** that share lifecycle responsibility (pre-checks,
+  cleanup, error handling, idempotency guards).
+- Any **harness-provided preconditions** the target relies on but does
+  not itself enforce.
+
+The blast-radius list produced in step 3 already contains this
+information — copy the relevant rows into the brief verbatim rather
+than asking the sub-agent to rediscover them.
+
+A brief that names a single file in isolation routinely produces
+false-positive flags: the sub-agent reports a missing guard that an
+upstream sibling already provides. Treat this as a brief defect, not
+a sub-agent defect.
 
 ## Grounding discipline
 


### PR DESCRIPTION
Adds a "call-graph context" rail to the architect skill so briefs to sub-agents include sibling scripts and harness-provided preconditions, not just the target file. Closes #68.

## How to read this PR?

1. `community-config/skills/architect/SKILL.md` — the only edited source. New `### 5. Briefing sub-agents (call-graph context)` block at lines 102-121, sitting between `### 4. Output formats` (line 90) and `## Grounding discipline` H2 (line 123). Version bumped at line 11 (`1.0.2 → 1.0.3`).
2. `.claude/skills/architect/SKILL.md` and `.gemini/skills/architect/SKILL.md` — regenerated mirrors, identical diff.

Source diffstat: 1 file, 22 insertions, 1 deletion. Total with bundles: 3 files, 66 insertions, 3 deletions.

## How to test this PR?

```bash
bash scripts/check-skill-versions.sh   # expect: exit 0
bash scripts/build-components.sh --target all --check
# expect: "OK: All generated files match source."
```

Then read the new `### 5.` block in `community-config/skills/architect/SKILL.md` and confirm:
- it lists entry points, sibling scripts, and harness preconditions as required brief inputs;
- it instructs the architect to copy the step-3 blast-radius list into the brief verbatim;
- it states that false-positive flags from sub-agents are brief defects, not sub-agent defects.

## Detailed description (for agents)

### Surface choice — why `architect/SKILL.md`, not `AGENTS.md` or a new skill

Three candidate surfaces were considered:

- **(a) `AGENTS.md`** — rejected. `AGENTS.md` governs git/PR/logbook conventions only; sub-agent briefing methodology is out of scope and would dilute the contract.
- **(b) New `team-mode` skill** — rejected. Disproportionate for a single additive rule; introducing a new skill carries a higher governance and discovery cost than the friction warrants (severity:low).
- **(c) Extend `architect/SKILL.md`** — chosen. The architect is the primary briefer-of-sub-agents in this harness; the rule belongs where the briefing actually happens. Insertion between `### 4. Output formats` and `## Grounding discipline` keeps the numbered subsections contiguous (4 → 5) and the H2 rails downstream.

Version bump is PATCH (`1.0.2 → 1.0.3`) because the change is additive friction-driven wording, not a contract change.

### Recursive coherence

This PR is itself an instance of the rule it adds: the brief I received for composing it included the call graph (architect's design rationale, doc-writer's exact line numbers, developer's regen commands, scripts invoked, diffstat, sibling files in the bundle pipeline). The chain held end-to-end because every upstream agent surfaced the sibling context their downstream needed — which is the property `### 5.` codifies.

### Chain summary

This is the 9th consecutive merge in the harness skill-quality chain:
#57 → #62 → #61 → #67 → #70 → #69 → #69-fixup → #63 → #64 → this. Each merge tightened either a rail (#67 grounding discipline, #70 bundler-regen step) or a curator/apply mechanic (#63, #64); this one closes a methodology gap exposed live by PR #60's tester run.

### Provenance

Issue #68 (`brief-missing-callgraph-context`, severity:low). The live evidence: in PR #60, a sub-agent flagged a `FileNotFoundError` risk if `gh` was missing in `apply.py`, unaware that `curate.sh:129` already enforced the pre-check upstream. Root cause was the brief, not the sub-agent — the rule now makes that explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)