### PR TITLE
📝 Guard against push_files exec-bit loss in pr-logbook and developer skills

### DIFF
--- a/.claude/skills/developer/SKILL.md
+++ b/.claude/skills/developer/SKILL.md
@@ -12,7 +12,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 
@@ -72,6 +72,11 @@ Before reporting a task as done, run:
   `bash scripts/build-components.sh --check` to confirm drift-free.
   This is non-optional — the CI `check-components` job rejects PRs
   where source and bundles disagree.
+- For changes that include shell scripts: after any push via the MCP
+  `push_files` tool (which strips file modes), verify the executable
+  bit survived. `git ls-files --stage -- '*.sh'` must show `100755`,
+  or `ls -la` show `755`. Restore with `git update-index --chmod=+x
+  <file>` before the next push.
 
 If the project has no test or type-check infrastructure, say so
 explicitly in the report — do not claim verification you did not do.

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.3"
+  version: "1.0.4"
 ---
 
 
@@ -107,6 +107,15 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 6. Pre-push sanity checks
+
+Text-only tooling silently drops file metadata. Verify before pushing:
+
+- If the diff touches shell scripts, confirm executable bits survived
+  the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
+  not `100644`. The MCP `push_files` tool strips the exec bit. Restore
+  with `git update-index --chmod=+x <file>` and amend before pushing.
 
 ## Cross-cutting: skill / agent source version bumps
 

--- a/.gemini/skills/developer/SKILL.md
+++ b/.gemini/skills/developer/SKILL.md
@@ -4,7 +4,7 @@ description: "Implementation skill for writing, modifying, and refactoring code.
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 
@@ -64,6 +64,11 @@ Before reporting a task as done, run:
   `bash scripts/build-components.sh --check` to confirm drift-free.
   This is non-optional — the CI `check-components` job rejects PRs
   where source and bundles disagree.
+- For changes that include shell scripts: after any push via the MCP
+  `push_files` tool (which strips file modes), verify the executable
+  bit survived. `git ls-files --stage -- '*.sh'` must show `100755`,
+  or `ls -la` show `755`. Restore with `git update-index --chmod=+x
+  <file>` before the next push.
 
 If the project has no test or type-check infrastructure, say so
 explicitly in the report — do not claim verification you did not do.

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -4,7 +4,7 @@ description: "Pull request and logbook composer. Activate when opening a PR, upd
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.3"
+  version: "1.0.4"
 ---
 
 
@@ -103,6 +103,15 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 6. Pre-push sanity checks
+
+Text-only tooling silently drops file metadata. Verify before pushing:
+
+- If the diff touches shell scripts, confirm executable bits survived
+  the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
+  not `100644`. The MCP `push_files` tool strips the exec bit. Restore
+  with `git update-index --chmod=+x <file>` and amend before pushing.
 
 ## Cross-cutting: skill / agent source version bumps
 

--- a/community-config/skills/developer/SKILL.md
+++ b/community-config/skills/developer/SKILL.md
@@ -8,7 +8,7 @@ type: skill
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.1"
+  version: "1.0.2"
 claude:
   allowed-tools:
     - Read
@@ -76,6 +76,11 @@ Before reporting a task as done, run:
   `bash scripts/build-components.sh --check` to confirm drift-free.
   This is non-optional — the CI `check-components` job rejects PRs
   where source and bundles disagree.
+- For changes that include shell scripts: after any push via the MCP
+  `push_files` tool (which strips file modes), verify the executable
+  bit survived. `git ls-files --stage -- '*.sh'` must show `100755`,
+  or `ls -la` show `755`. Restore with `git update-index --chmod=+x
+  <file>` before the next push.
 
 If the project has no test or type-check infrastructure, say so
 explicitly in the report — do not claim verification you did not do.

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -8,7 +8,7 @@ type: skill
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.3"
+  version: "1.0.4"
 claude:
   allowed-tools:
     - Read
@@ -111,6 +111,15 @@ Co-authored-by lines, if any.
 ```
 
 Do not paste the entire PR description. The commit message is denser.
+
+### 6. Pre-push sanity checks
+
+Text-only tooling silently drops file metadata. Verify before pushing:
+
+- If the diff touches shell scripts, confirm executable bits survived
+  the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
+  not `100644`. The MCP `push_files` tool strips the exec bit. Restore
+  with `git update-index --chmod=+x <file>` and amend before pushing.
 
 ## Cross-cutting: skill / agent source version bumps
 


### PR DESCRIPTION
Adds a pre-push sanity check to pr-logbook and a `push_files` guard to developer, both triggered by issue #81 (mcp-push-files-mode-loss friction cluster). The MCP `push_files` tool silently strips executable bits from shell scripts; these additions make that failure mode visible before it reaches a reviewer.

## How to read this PR?

Both changes are additive — no existing content is removed or reworded.

- `pr-logbook/SKILL.md` § Operating mode → new **§ 6 Pre-push sanity checks**: a checklist item to run `git ls-files --stage -- '*.sh'` before pushing and restore with `git update-index --chmod=+x` if modes are `100644`.
- `developer/SKILL.md` § 3 Prove it locally: new bullet for the same `push_files` exec-bit check, conditioned on "if the diff touches shell scripts".

Read the two SKILL.md diffs top-down; both are insertions at the end of an existing list or section.

## How to test this PR?

1. Read both SKILL.md sections and confirm the guard matches the actual failure mode documented in issue #81 (evidence: `dfb0da7`).
2. Run `bash scripts/build-components.sh` and confirm bundles regenerate cleanly.
3. Verify all modified `.sh` files remain `755` after commit: `git ls-files --stage -- '*.sh'` must show `100755`.

## Detailed description (for agents)

**`pr-logbook/SKILL.md`** — new `### 6. Pre-push sanity checks` subsection inserted between § 5 (commit message) and `## Cross-cutting`. Content: one bullet, `push_files`-specific, with exact commands. `provenance.version` bumped `1.0.3 → 1.0.4` (PATCH).

**`developer/SKILL.md`** — one bullet appended to the `### 3. Prove it locally` list, conditioned on shell-script changes, naming `push_files` as the root cause. `provenance.version` bumped `1.0.1 → 1.0.2` (PATCH).

Both version bumps trigger `check-skill-versions` CI guard; bundles must be regenerated in the same commit.

Closes #81.