### PR TITLE
📝 Add license and compatibility fields to V0 skills for agentskills.io spec

### DIFF
--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: architect
 description: "Design and architecture skill for ADRs, RFCs, design reviews, and ripple-effect analysis. Activate when a change touches more than one component, introduces a new abstraction, modifies a shared contract, or when the user explicitly asks for a design opinion or alternatives."
+license: Apache-2.0
 allowed-tools:
   - Read
   - Grep

--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.3"
+  version: "1.0.4"
 ---
 
 

--- a/.claude/skills/ci-workflow-engineering/SKILL.md
+++ b/.claude/skills/ci-workflow-engineering/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: ci-workflow-engineering
 description: "Structured approach for building, debugging, and hardening CI/CD pipelines. Activate when the agent needs to: create new workflow definitions, diagnose failing jobs, validate pipeline changes on a branch before merge, or integrate platform-specific resources (secrets, registries, certificates)."
+license: Apache-2.0
+compatibility: "Requires the gh CLI (for fetching workflow runs and job logs) and bash. Optional: act for local workflow execution."
 allowed-tools:
   - Read
   - Write
@@ -12,7 +14,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 

--- a/.claude/skills/developer/SKILL.md
+++ b/.claude/skills/developer/SKILL.md
@@ -12,7 +12,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.2"
+  version: "1.0.3"
 ---
 
 

--- a/.claude/skills/developer/SKILL.md
+++ b/.claude/skills/developer/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: developer
 description: "Implementation skill for writing, modifying, and refactoring code. Activate by default for any coding task that does not warrant the architect skill. Optimised for parallelisable execution, fast feedback loops, and minimal surface area per change."
+license: Apache-2.0
+compatibility: "Requires bash (used by scripts/build-components.sh) and git (used for staged-file inspection of executable bits)."
 allowed-tools:
   - Read
   - Write

--- a/.claude/skills/doc-writer/SKILL.md
+++ b/.claude/skills/doc-writer/SKILL.md
@@ -11,7 +11,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 

--- a/.claude/skills/doc-writer/SKILL.md
+++ b/.claude/skills/doc-writer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: doc-writer
 description: "Documentation skill for ADRs, READMEs, in-code docstrings, and reference material. Activate when the user asks for documentation, when a public contract changes without docs, or when an ADR is needed per the architect skill's output. Optimised for documents that age well."
+license: Apache-2.0
 allowed-tools:
   - Read
   - Write

--- a/.claude/skills/harness-curator/SKILL.md
+++ b/.claude/skills/harness-curator/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: harness-curator
 description: "Harness feedback-loop curator. Activate on demand to read friction tags from the global harness-friction wing, cluster them, and open one descriptive issue per cluster on the canonical/feedback repos declared in components' provenance blocks. The fix MR lands later (human-authored or via the auto-fix mode tracked in #42)."
+license: Apache-2.0
+compatibility: "Requires bash, jq, the gh CLI (used by setup-labels.sh and --apply), and the mempalace Python package (pipx install 'mempalace>=3.3.3,<3.4')."
 allowed-tools:
   - Read
   - Bash

--- a/.claude/skills/harness-curator/SKILL.md
+++ b/.claude/skills/harness-curator/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.1.0"
+  version: "1.1.1"
 ---
 
 

--- a/.claude/skills/harness-report/SKILL.md
+++ b/.claude/skills/harness-report/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: harness-report
 description: "Tag a friction encountered during real work. Activate the moment any recognition signal fires (user pushback, second-time tool surprise, sibling-skill workaround, etc.). The single canonical implementation of the friction-tagging protocol — all other skills point here."
+license: Apache-2.0
 allowed-tools:
   - Read
 user-invocable: true

--- a/.claude/skills/harness-report/SKILL.md
+++ b/.claude/skills/harness-report/SKILL.md
@@ -7,7 +7,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pr-logbook
 description: "Pull request and logbook composer. Activate when opening a PR, updating a PR description, or appending to a logbook issue. Produces titles, bodies, test plans, and logbook entries that conform to the project's AGENTS.md conventions."
+license: Apache-2.0
+compatibility: "Requires git (for log and staged-file inspection), the gh CLI (for PR creation and logbook issue updates), and bash."
 allowed-tools:
   - Read
   - Bash

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.4"
+  version: "1.0.5"
 ---
 
 

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security
 description: "Security review skill for threat modeling, dependency audit, secret hygiene, and code review through a security lens. Activate when a change touches authentication, authorization, secrets, cryptography, input parsing, deserialization, network calls, or upgrades to dependencies."
+license: Apache-2.0
 allowed-tools:
   - Read
   - Grep

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 

--- a/.claude/skills/tester/SKILL.md
+++ b/.claude/skills/tester/SKILL.md
@@ -12,7 +12,7 @@ user-invocable: true
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 

--- a/.claude/skills/tester/SKILL.md
+++ b/.claude/skills/tester/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tester
 description: "Test authoring and test-strategy skill. Activate when writing new tests, planning a test strategy, enumerating edge cases for a feature, or reviewing whether a change has adequate coverage. Optimised for high-signal tests that catch regressions, not coverage theatre."
+license: Apache-2.0
 allowed-tools:
   - Read
   - Write

--- a/.gemini/skills/architect/SKILL.md
+++ b/.gemini/skills/architect/SKILL.md
@@ -4,7 +4,7 @@ description: "Design and architecture skill for ADRs, RFCs, design reviews, and 
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.3"
+  version: "1.0.4"
 ---
 
 

--- a/.gemini/skills/architect/SKILL.md
+++ b/.gemini/skills/architect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: architect
 description: "Design and architecture skill for ADRs, RFCs, design reviews, and ripple-effect analysis. Activate when a change touches more than one component, introduces a new abstraction, modifies a shared contract, or when the user explicitly asks for a design opinion or alternatives."
+license: Apache-2.0
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"

--- a/.gemini/skills/ci-workflow-engineering/SKILL.md
+++ b/.gemini/skills/ci-workflow-engineering/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: ci-workflow-engineering
 description: "Structured approach for building, debugging, and hardening CI/CD pipelines. Activate when the agent needs to: create new workflow definitions, diagnose failing jobs, validate pipeline changes on a branch before merge, or integrate platform-specific resources (secrets, registries, certificates)."
+license: Apache-2.0
+compatibility: "Requires the gh CLI (for fetching workflow runs and job logs) and bash. Optional: act for local workflow execution."
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 

--- a/.gemini/skills/developer/SKILL.md
+++ b/.gemini/skills/developer/SKILL.md
@@ -4,7 +4,7 @@ description: "Implementation skill for writing, modifying, and refactoring code.
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.2"
+  version: "1.0.3"
 ---
 
 

--- a/.gemini/skills/developer/SKILL.md
+++ b/.gemini/skills/developer/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: developer
 description: "Implementation skill for writing, modifying, and refactoring code. Activate by default for any coding task that does not warrant the architect skill. Optimised for parallelisable execution, fast feedback loops, and minimal surface area per change."
+license: Apache-2.0
+compatibility: "Requires bash (used by scripts/build-components.sh) and git (used for staged-file inspection of executable bits)."
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"

--- a/.gemini/skills/doc-writer/SKILL.md
+++ b/.gemini/skills/doc-writer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: doc-writer
 description: "Documentation skill for ADRs, READMEs, in-code docstrings, and reference material. Activate when the user asks for documentation, when a public contract changes without docs, or when an ADR is needed per the architect skill's output. Optimised for documents that age well."
+license: Apache-2.0
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"

--- a/.gemini/skills/doc-writer/SKILL.md
+++ b/.gemini/skills/doc-writer/SKILL.md
@@ -4,7 +4,7 @@ description: "Documentation skill for ADRs, READMEs, in-code docstrings, and ref
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 

--- a/.gemini/skills/harness-curator/SKILL.md
+++ b/.gemini/skills/harness-curator/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: harness-curator
 description: "Harness feedback-loop curator. Activate on demand to read friction tags from the global harness-friction wing, cluster them, and open one descriptive issue per cluster on the canonical/feedback repos declared in components' provenance blocks. The fix MR lands later (human-authored or via the auto-fix mode tracked in #42)."
+license: Apache-2.0
+compatibility: "Requires bash, jq, the gh CLI (used by setup-labels.sh and --apply), and the mempalace Python package (pipx install 'mempalace>=3.3.3,<3.4')."
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"

--- a/.gemini/skills/harness-curator/SKILL.md
+++ b/.gemini/skills/harness-curator/SKILL.md
@@ -4,7 +4,7 @@ description: "Harness feedback-loop curator. Activate on demand to read friction
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.1.0"
+  version: "1.1.1"
 ---
 
 

--- a/.gemini/skills/harness-report/SKILL.md
+++ b/.gemini/skills/harness-report/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: harness-report
 description: "Tag a friction encountered during real work. Activate the moment any recognition signal fires (user pushback, second-time tool surprise, sibling-skill workaround, etc.). The single canonical implementation of the friction-tagging protocol — all other skills point here."
+license: Apache-2.0
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"

--- a/.gemini/skills/harness-report/SKILL.md
+++ b/.gemini/skills/harness-report/SKILL.md
@@ -4,7 +4,7 @@ description: "Tag a friction encountered during real work. Activate the moment a
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pr-logbook
 description: "Pull request and logbook composer. Activate when opening a PR, updating a PR description, or appending to a logbook issue. Produces titles, bodies, test plans, and logbook entries that conform to the project's AGENTS.md conventions."
+license: Apache-2.0
+compatibility: "Requires git (for log and staged-file inspection), the gh CLI (for PR creation and logbook issue updates), and bash."
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -4,7 +4,7 @@ description: "Pull request and logbook composer. Activate when opening a PR, upd
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.4"
+  version: "1.0.5"
 ---
 
 

--- a/.gemini/skills/security/SKILL.md
+++ b/.gemini/skills/security/SKILL.md
@@ -4,7 +4,7 @@ description: "Security review skill for threat modeling, dependency audit, secre
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 

--- a/.gemini/skills/security/SKILL.md
+++ b/.gemini/skills/security/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security
 description: "Security review skill for threat modeling, dependency audit, secret hygiene, and code review through a security lens. Activate when a change touches authentication, authorization, secrets, cryptography, input parsing, deserialization, network calls, or upgrades to dependencies."
+license: Apache-2.0
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"

--- a/.gemini/skills/tester/SKILL.md
+++ b/.gemini/skills/tester/SKILL.md
@@ -4,7 +4,7 @@ description: "Test authoring and test-strategy skill. Activate when writing new 
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 

--- a/.gemini/skills/tester/SKILL.md
+++ b/.gemini/skills/tester/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tester
 description: "Test authoring and test-strategy skill. Activate when writing new tests, planning a test strategy, enumerating edge cases for a feature, or reviewing whether a change has adequate coverage. Optimised for high-signal tests that catch regressions, not coverage theatre."
+license: Apache-2.0
 provenance:
   canonical: "https://github.com/hcross/crewrig"
   feedback: "https://github.com/hcross/crewrig"

--- a/community-config/skills/architect/SKILL.md
+++ b/community-config/skills/architect/SKILL.md
@@ -5,10 +5,11 @@ description: "Design and architecture skill for ADRs, RFCs, design reviews,
   component, introduces a new abstraction, modifies a shared contract, or when
   the user explicitly asks for a design opinion or alternatives."
 type: skill
+license: Apache-2.0
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.3"
+  version: "1.0.4"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/ci-workflow-engineering/SKILL.md
+++ b/community-config/skills/ci-workflow-engineering/SKILL.md
@@ -6,7 +6,7 @@ description: "Structured approach for building, debugging, and hardening CI/CD
   or integrate platform-specific resources (secrets, registries, certificates)."
 type: skill
 license: Apache-2.0
-compatibility: Requires the gh CLI (for fetching workflow runs and job logs) and bash. Optional: act for local workflow execution.
+compatibility: "Requires the gh CLI (for fetching workflow runs and job logs) and bash. Optional: act for local workflow execution."
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"

--- a/community-config/skills/ci-workflow-engineering/SKILL.md
+++ b/community-config/skills/ci-workflow-engineering/SKILL.md
@@ -5,10 +5,12 @@ description: "Structured approach for building, debugging, and hardening CI/CD
   diagnose failing jobs, validate pipeline changes on a branch before merge,
   or integrate platform-specific resources (secrets, registries, certificates)."
 type: skill
+license: Apache-2.0
+compatibility: Requires the gh CLI (for fetching workflow runs and job logs) and bash. Optional: act for local workflow execution.
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+  version: "1.0.1"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/developer/SKILL.md
+++ b/community-config/skills/developer/SKILL.md
@@ -6,7 +6,7 @@ description: "Implementation skill for writing, modifying, and refactoring
   loops, and minimal surface area per change."
 type: skill
 license: Apache-2.0
-compatibility: Requires bash (used by scripts/build-components.sh) and git (used for staged-file inspection of executable bits).
+compatibility: "Requires bash (used by scripts/build-components.sh) and git (used for staged-file inspection of executable bits)."
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"

--- a/community-config/skills/developer/SKILL.md
+++ b/community-config/skills/developer/SKILL.md
@@ -5,10 +5,12 @@ description: "Implementation skill for writing, modifying, and refactoring
   architect skill. Optimised for parallelisable execution, fast feedback
   loops, and minimal surface area per change."
 type: skill
+license: Apache-2.0
+compatibility: Requires bash (used by scripts/build-components.sh) and git (used for staged-file inspection of executable bits).
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.2"
+  version: "1.0.3"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/doc-writer/SKILL.md
+++ b/community-config/skills/doc-writer/SKILL.md
@@ -5,10 +5,11 @@ description: "Documentation skill for ADRs, READMEs, in-code docstrings, and
   public contract changes without docs, or when an ADR is needed per the
   architect skill's output. Optimised for documents that age well."
 type: skill
+license: Apache-2.0
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+  version: "1.0.1"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/harness-curator/SKILL.md
+++ b/community-config/skills/harness-curator/SKILL.md
@@ -6,11 +6,12 @@ description: "Harness feedback-loop curator. Activate on demand to read
   declared in components' provenance blocks. The fix MR lands later
   (human-authored or via the auto-fix mode tracked in #42)."
 type: skill
+license: Apache-2.0
 compatibility: Requires bash, jq, the gh CLI (used by setup-labels.sh and --apply), and the mempalace Python package (pipx install 'mempalace>=3.3.3,<3.4').
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.1.0"
+  version: "1.1.1"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/harness-report/SKILL.md
+++ b/community-config/skills/harness-report/SKILL.md
@@ -5,10 +5,11 @@ description: "Tag a friction encountered during real work. Activate the moment
   sibling-skill workaround, etc.). The single canonical implementation of
   the friction-tagging protocol — all other skills point here."
 type: skill
+license: Apache-2.0
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.1"
+  version: "1.0.2"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -5,10 +5,12 @@ description: "Pull request and logbook composer. Activate when opening a PR,
   bodies, test plans, and logbook entries that conform to the project's
   AGENTS.md conventions."
 type: skill
+license: Apache-2.0
+compatibility: Requires git (for log and staged-file inspection), the gh CLI (for PR creation and logbook issue updates), and bash.
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.4"
+  version: "1.0.5"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -6,7 +6,7 @@ description: "Pull request and logbook composer. Activate when opening a PR,
   AGENTS.md conventions."
 type: skill
 license: Apache-2.0
-compatibility: Requires git (for log and staged-file inspection), the gh CLI (for PR creation and logbook issue updates), and bash.
+compatibility: "Requires git (for log and staged-file inspection), the gh CLI (for PR creation and logbook issue updates), and bash."
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"

--- a/community-config/skills/security/SKILL.md
+++ b/community-config/skills/security/SKILL.md
@@ -5,10 +5,11 @@ description: "Security review skill for threat modeling, dependency audit,
   change touches authentication, authorization, secrets, cryptography, input
   parsing, deserialization, network calls, or upgrades to dependencies."
 type: skill
+license: Apache-2.0
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+  version: "1.0.1"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/tester/SKILL.md
+++ b/community-config/skills/tester/SKILL.md
@@ -5,10 +5,11 @@ description: "Test authoring and test-strategy skill. Activate when writing
   or reviewing whether a change has adequate coverage. Optimised for
   high-signal tests that catch regressions, not coverage theatre."
 type: skill
+license: Apache-2.0
 provenance:
   canonical: "${CANONICAL_REPO}"
   feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+  version: "1.0.1"
 claude:
   allowed-tools:
     - Read

--- a/scripts/build-components.sh
+++ b/scripts/build-components.sh
@@ -275,11 +275,25 @@ build_skills() {
 
     # --- Gemini CLI output ---
     if [ "$TARGET" = "gemini" ] || [ "$TARGET" = "all" ]; then
+      local license compatibility
+      license=$(yaml_field "$source" "license")
+      compatibility=$(yaml_field "$source" "compatibility")
+
+      local gemini_frontmatter="name: $name
+description: \"$description\""
+      if [ -n "$license" ] && [ "$license" != "null" ]; then
+        gemini_frontmatter="$gemini_frontmatter
+license: $license"
+      fi
+      if [ -n "$compatibility" ] && [ "$compatibility" != "null" ]; then
+        gemini_frontmatter="$gemini_frontmatter
+compatibility: \"$compatibility\""
+      fi
+
       local gemini_content
       gemini_content=$(cat <<GEMINI_EOF
 ---
-name: $name
-description: "$description"
+$gemini_frontmatter
 ---
 
 $body
@@ -293,6 +307,18 @@ GEMINI_EOF
     if [ "$TARGET" = "claude" ] || [ "$TARGET" = "all" ]; then
       local claude_frontmatter="name: $name
 description: \"$description\""
+
+      local license compatibility
+      license=$(yaml_field "$source" "license")
+      compatibility=$(yaml_field "$source" "compatibility")
+      if [ -n "$license" ] && [ "$license" != "null" ]; then
+        claude_frontmatter="$claude_frontmatter
+license: $license"
+      fi
+      if [ -n "$compatibility" ] && [ "$compatibility" != "null" ]; then
+        claude_frontmatter="$claude_frontmatter
+compatibility: \"$compatibility\""
+      fi
 
       # Add Claude-specific fields if present
       local allowed_tools


### PR DESCRIPTION
Addresses the actionable findings from the agentskills.io spec compliance audit (issue #55). Adds the missing `license: Apache-2.0` field to all 9 V0 skills and declares `compatibility:` on the three skills with non-trivial runtime dependencies. The `provenance:` top-level nesting issue is deliberately out of scope here — it is tracked and will be migrated in issue #54.

## How to read this PR?

All changes are purely frontmatter additions. No skill body content was modified.

Read any one SKILL.md diff to see the pattern — it is mechanical and identical across the 9 source files:
1. `license: Apache-2.0` inserted after `type: skill`
2. `compatibility:` inserted on developer, pr-logbook, and ci-workflow-engineering (after `license:`, before `provenance:`)
3. PATCH version bump on `provenance.version`

The 4 bundle files per skill regenerate automatically from `scripts/build-components.sh`.

## How to test this PR?

```bash
# Verify license on all 9 source skills
grep -l "license: Apache-2.0" community-config/skills/*/SKILL.md | wc -l
# Expected: 9

# Verify compatibility on the 3 targeted skills
grep "compatibility:" community-config/skills/developer/SKILL.md
grep "compatibility:" community-config/skills/pr-logbook/SKILL.md
grep "compatibility:" community-config/skills/ci-workflow-engineering/SKILL.md

# Verify bundles are drift-free
bash scripts/build-components.sh --check
```

## Detailed description (for agents)

**Scope of this PR (issue #55 actionable findings only):**

- `license: Apache-2.0` — the spec defines this as a recognised top-level frontmatter field. The repo LICENSE file confirms Apache-2.0. Added to all 9 skills. Positioned after `type: skill`, before `provenance:`, consistent with harness-curator which was the only skill previously declaring `compatibility:`.

- `compatibility:` — added to three skills with non-trivial runtime dependencies:
  - `developer`: bash + git (build-components.sh, git ls-files --stage, git update-index)
  - `pr-logbook`: git + gh CLI + bash (log inspection, PR creation, logbook issue updates)
  - `ci-workflow-engineering`: gh CLI + bash; act optional (local workflow execution)

- Version bumps: PATCH on all 9 modified skills (non-breaking additive frontmatter change).

**Explicitly out of scope:**
- `provenance:` top-level → `metadata.provenance:` migration: tracked in issue #54.
- `skills-ref validate` tooling: not installed; validation deferred until the tool is available.
- Body length / reference extraction: all 9 skills are already < 500 lines; no extraction needed.

Partially addresses #55.