### PR TITLE
♻️ Migrate provenance: to metadata.provenance: per agentskills.io spec

### DIFF
--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -1,10 +1,11 @@
 ---
 name: architect
 description: "Generic architecture agent. Drafts ADRs, runs design reviews, proposes alternatives with explicit trade-offs, and maps blast radius."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/agents/developer/AGENT.md
+++ b/.claude/agents/developer/AGENT.md
@@ -1,10 +1,11 @@
 ---
 name: developer
 description: "Generic implementation agent. Writes, edits, and refactors code with the smallest correct change. Verifies locally before reporting done."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/agents/doc-writer/AGENT.md
+++ b/.claude/agents/doc-writer/AGENT.md
@@ -1,10 +1,11 @@
 ---
 name: doc-writer
 description: "Generic documentation agent. Drafts ADRs, READMEs, in-code docstrings, and reference material. Optimises for documents that age well and stays close to the code where possible."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/agents/harness-curator/AGENT.md
+++ b/.claude/agents/harness-curator/AGENT.md
@@ -1,10 +1,11 @@
 ---
 name: harness-curator
 description: "Generic harness-curator agent. On-demand reader of the global harness-friction wing. Clusters frictions, opens one descriptive feedback issue per cluster against the canonical/feedback repos. The fix MR lands later (human-authored or via auto-fix mode #42)."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/agents/pr-logbook/AGENT.md
+++ b/.claude/agents/pr-logbook/AGENT.md
@@ -1,10 +1,11 @@
 ---
 name: pr-logbook
 description: "Generic PR and logbook composer agent. Drafts titles, bodies, test plans, logbook entries, and squash-merge commit messages that conform to the project's AGENTS.md conventions."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/agents/security/AGENT.md
+++ b/.claude/agents/security/AGENT.md
@@ -1,10 +1,11 @@
 ---
 name: security
 description: "Generic security review agent. Threat modeling, secret hygiene, realistic-threat code review, dependency audit. Findings only — does not implement fixes unless explicitly asked."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/agents/tester/AGENT.md
+++ b/.claude/agents/tester/AGENT.md
@@ -1,10 +1,11 @@
 ---
 name: tester
 description: "Generic test-authoring agent. Writes high-signal regression tests, enumerates priority edge cases, and verifies fixes by failing-then-passing the test against the bug."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -8,10 +8,11 @@ allowed-tools:
   - Glob
   - Bash
 user-invocable: true
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.4"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/skills/ci-workflow-engineering/SKILL.md
+++ b/.claude/skills/ci-workflow-engineering/SKILL.md
@@ -11,10 +11,11 @@ allowed-tools:
   - Grep
   - Glob
 user-invocable: true
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/skills/developer/SKILL.md
+++ b/.claude/skills/developer/SKILL.md
@@ -11,10 +11,11 @@ allowed-tools:
   - Grep
   - Glob
 user-invocable: true
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.3"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/skills/doc-writer/SKILL.md
+++ b/.claude/skills/doc-writer/SKILL.md
@@ -9,10 +9,11 @@ allowed-tools:
   - Grep
   - Glob
 user-invocable: true
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/skills/harness-curator/SKILL.md
+++ b/.claude/skills/harness-curator/SKILL.md
@@ -9,10 +9,11 @@ allowed-tools:
   - Grep
   - Glob
 user-invocable: true
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.1.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.2.0"
 ---
 
 

--- a/.claude/skills/harness-report/SKILL.md
+++ b/.claude/skills/harness-report/SKILL.md
@@ -5,10 +5,11 @@ license: Apache-2.0
 allowed-tools:
   - Read
 user-invocable: true
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.2"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -7,10 +7,11 @@ allowed-tools:
   - Read
   - Bash
 user-invocable: true
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.5"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -8,10 +8,11 @@ allowed-tools:
   - Glob
   - Bash
 user-invocable: true
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.claude/skills/tester/SKILL.md
+++ b/.claude/skills/tester/SKILL.md
@@ -10,10 +10,11 @@ allowed-tools:
   - Grep
   - Glob
 user-invocable: true
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/agents/architect.md
+++ b/.gemini/agents/architect.md
@@ -1,10 +1,11 @@
 ---
 name: architect
 description: "Generic architecture agent. Drafts ADRs, runs design reviews, proposes alternatives with explicit trade-offs, and maps blast radius."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/agents/developer.md
+++ b/.gemini/agents/developer.md
@@ -1,10 +1,11 @@
 ---
 name: developer
 description: "Generic implementation agent. Writes, edits, and refactors code with the smallest correct change. Verifies locally before reporting done."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/agents/doc-writer.md
+++ b/.gemini/agents/doc-writer.md
@@ -1,10 +1,11 @@
 ---
 name: doc-writer
 description: "Generic documentation agent. Drafts ADRs, READMEs, in-code docstrings, and reference material. Optimises for documents that age well and stays close to the code where possible."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/agents/harness-curator.md
+++ b/.gemini/agents/harness-curator.md
@@ -1,10 +1,11 @@
 ---
 name: harness-curator
 description: "Generic harness-curator agent. On-demand reader of the global harness-friction wing. Clusters frictions, opens one descriptive feedback issue per cluster against the canonical/feedback repos. The fix MR lands later (human-authored or via auto-fix mode #42)."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/agents/pr-logbook.md
+++ b/.gemini/agents/pr-logbook.md
@@ -1,10 +1,11 @@
 ---
 name: pr-logbook
 description: "Generic PR and logbook composer agent. Drafts titles, bodies, test plans, logbook entries, and squash-merge commit messages that conform to the project's AGENTS.md conventions."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/agents/security.md
+++ b/.gemini/agents/security.md
@@ -1,10 +1,11 @@
 ---
 name: security
 description: "Generic security review agent. Threat modeling, secret hygiene, realistic-threat code review, dependency audit. Findings only — does not implement fixes unless explicitly asked."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/agents/tester.md
+++ b/.gemini/agents/tester.md
@@ -1,10 +1,11 @@
 ---
 name: tester
 description: "Generic test-authoring agent. Writes high-signal regression tests, enumerates priority edge cases, and verifies fixes by failing-then-passing the test against the bug."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/skills/architect/SKILL.md
+++ b/.gemini/skills/architect/SKILL.md
@@ -2,10 +2,11 @@
 name: architect
 description: "Design and architecture skill for ADRs, RFCs, design reviews, and ripple-effect analysis. Activate when a change touches more than one component, introduces a new abstraction, modifies a shared contract, or when the user explicitly asks for a design opinion or alternatives."
 license: Apache-2.0
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.4"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/skills/ci-workflow-engineering/SKILL.md
+++ b/.gemini/skills/ci-workflow-engineering/SKILL.md
@@ -3,10 +3,11 @@ name: ci-workflow-engineering
 description: "Structured approach for building, debugging, and hardening CI/CD pipelines. Activate when the agent needs to: create new workflow definitions, diagnose failing jobs, validate pipeline changes on a branch before merge, or integrate platform-specific resources (secrets, registries, certificates)."
 license: Apache-2.0
 compatibility: "Requires the gh CLI (for fetching workflow runs and job logs) and bash. Optional: act for local workflow execution."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/skills/developer/SKILL.md
+++ b/.gemini/skills/developer/SKILL.md
@@ -3,10 +3,11 @@ name: developer
 description: "Implementation skill for writing, modifying, and refactoring code. Activate by default for any coding task that does not warrant the architect skill. Optimised for parallelisable execution, fast feedback loops, and minimal surface area per change."
 license: Apache-2.0
 compatibility: "Requires bash (used by scripts/build-components.sh) and git (used for staged-file inspection of executable bits)."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.3"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/skills/doc-writer/SKILL.md
+++ b/.gemini/skills/doc-writer/SKILL.md
@@ -2,10 +2,11 @@
 name: doc-writer
 description: "Documentation skill for ADRs, READMEs, in-code docstrings, and reference material. Activate when the user asks for documentation, when a public contract changes without docs, or when an ADR is needed per the architect skill's output. Optimised for documents that age well."
 license: Apache-2.0
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/skills/harness-curator/SKILL.md
+++ b/.gemini/skills/harness-curator/SKILL.md
@@ -3,10 +3,11 @@ name: harness-curator
 description: "Harness feedback-loop curator. Activate on demand to read friction tags from the global harness-friction wing, cluster them, and open one descriptive issue per cluster on the canonical/feedback repos declared in components' provenance blocks. The fix MR lands later (human-authored or via the auto-fix mode tracked in #42)."
 license: Apache-2.0
 compatibility: "Requires bash, jq, the gh CLI (used by setup-labels.sh and --apply), and the mempalace Python package (pipx install 'mempalace>=3.3.3,<3.4')."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.1.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.2.0"
 ---
 
 

--- a/.gemini/skills/harness-report/SKILL.md
+++ b/.gemini/skills/harness-report/SKILL.md
@@ -2,10 +2,11 @@
 name: harness-report
 description: "Tag a friction encountered during real work. Activate the moment any recognition signal fires (user pushback, second-time tool surprise, sibling-skill workaround, etc.). The single canonical implementation of the friction-tagging protocol — all other skills point here."
 license: Apache-2.0
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.2"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -3,10 +3,11 @@ name: pr-logbook
 description: "Pull request and logbook composer. Activate when opening a PR, updating a PR description, or appending to a logbook issue. Produces titles, bodies, test plans, and logbook entries that conform to the project's AGENTS.md conventions."
 license: Apache-2.0
 compatibility: "Requires git (for log and staged-file inspection), the gh CLI (for PR creation and logbook issue updates), and bash."
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.5"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/skills/security/SKILL.md
+++ b/.gemini/skills/security/SKILL.md
@@ -2,10 +2,11 @@
 name: security
 description: "Security review skill for threat modeling, dependency audit, secret hygiene, and code review through a security lens. Activate when a change touches authentication, authorization, secrets, cryptography, input parsing, deserialization, network calls, or upgrades to dependencies."
 license: Apache-2.0
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/.gemini/skills/tester/SKILL.md
+++ b/.gemini/skills/tester/SKILL.md
@@ -2,10 +2,11 @@
 name: tester
 description: "Test authoring and test-strategy skill. Activate when writing new tests, planning a test strategy, enumerating edge cases for a feature, or reviewing whether a change has adequate coverage. Optimised for high-signal tests that catch regressions, not coverage theatre."
 license: Apache-2.0
-provenance:
-  canonical: "https://github.com/hcross/crewrig"
-  feedback: "https://github.com/hcross/crewrig"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "https://github.com/hcross/crewrig"
+    feedback: "https://github.com/hcross/crewrig"
+    version: "1.1.0"
 ---
 
 

--- a/community-config/FORMAT.md
+++ b/community-config/FORMAT.md
@@ -77,6 +77,7 @@ Detailed instructions, workflows, constraints...
 | `name` | string | Component identifier (kebab-case) |
 | `description` | string | Brief description for discovery. Used by both tools. |
 | `type` | string | `skill`, `command`, or `agent` |
+| `metadata` | mapping | Optional container recognised by the agentskills.io spec for non-standard keys. crewrig curates `metadata.provenance` here (see [Provenance & Forks](#provenance--forks)). |
 
 ### Gemini CLI Overrides (optional)
 
@@ -185,10 +186,11 @@ Gemini CLI → `.gemini/agents/<name>.md`
 ---
 name: <name>
 description: <description>
-provenance:        # propagated when present in source
-  canonical: ...
-  feedback: ...
-  version: ...
+metadata:          # propagated when source declares metadata.provenance
+  provenance:
+    canonical: ...
+    feedback: ...
+    version: ...
 ---
 <body — becomes the agent's system prompt>
 ```
@@ -205,19 +207,27 @@ description: <description>
 
 ## Provenance & Forks
 
-Components carry a `provenance:` block in their frontmatter that survives
-forks and lets feedback flow back to the right repo. The block is
-optional but recommended for any component intended to be re-shared.
+Components carry a `metadata.provenance:` block in their frontmatter that
+survives forks and lets feedback flow back to the right repo. The block
+is optional but recommended for any component intended to be re-shared.
+
+`provenance` lives under `metadata:` to keep the root frontmatter
+restricted to fields recognised by the
+[agentskills.io specification](https://agentskills.io/specification)
+(`name`, `description`, `license`, `compatibility`, `metadata`,
+`allowed-tools`). The spec reserves `metadata:` for non-standard keys —
+crewrig curates `provenance` there.
 
 ```yaml
 ---
 name: my-component
 description: "..."
 type: skill
-provenance:
-  canonical: "${CANONICAL_REPO}"   # origin (audit + license trace)
-  feedback:  "${FEEDBACK_REPO}"    # MR target (defaults to canonical)
-  version:   "1.0.0"               # version at build/import
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"   # origin (audit + license trace)
+    feedback:  "${FEEDBACK_REPO}"    # MR target (defaults to canonical)
+    version:   "1.0.0"               # version at build/import
 ---
 ```
 
@@ -234,9 +244,9 @@ feedback_repo  = "https://github.com/hcross/crewrig"
 
 The build substitutes every `${KEY}` placeholder it encounters in the
 generated outputs (`.gemini/`, `.claude/`) — frontmatter **and** body —
-not only inside the `provenance:` block. This is intentional: components
-may reference `${CANONICAL_REPO}` or other config keys in their prompt
-body too. Source files keep the placeholders untouched.
+not only inside the `metadata.provenance:` block. This is intentional:
+components may reference `${CANONICAL_REPO}` or other config keys in
+their prompt body too. Source files keep the placeholders untouched.
 
 ### Forking workflow
 
@@ -251,13 +261,14 @@ When you fork crewrig (or a fork of it):
    values.
 3. Commit both `crewrig.config.toml` and the regenerated outputs.
 
-The `version:` field in `provenance:` is a literal per-component
-string, not a placeholder. It tracks the component's own evolution
-independently from the host repo.
+The `version:` field in `metadata.provenance:` is a literal
+per-component string, not a placeholder. It tracks the component's own
+evolution independently from the host repo.
 
 ### Version semantics (SemVer)
 
-The `version:` field follows [Semantic Versioning](https://semver.org/)
+The `metadata.provenance.version` field follows
+[Semantic Versioning](https://semver.org/)
 (`MAJOR.MINOR.PATCH`):
 
 | Bump | When |
@@ -267,8 +278,8 @@ The `version:` field follows [Semantic Versioning](https://semver.org/)
 | **MAJOR** (`1.1.0 → 2.0.0`) | Breaking contract change. Removed payload fields, renamed required fields, semantics flip. Forks pinning `1.x` need to migrate consciously. |
 
 **Bump rule.** Every PR that touches a `SKILL.md` or `AGENT.md`
-source under `community-config/` MUST bump `provenance.version` in
-the same diff. CI enforces this via `scripts/check-skill-versions.sh`
+source under `community-config/` MUST bump `metadata.provenance.version`
+in the same diff. CI enforces this via `scripts/check-skill-versions.sh`
 (see `task check-skill-versions` for the local invocation). The
 rationale:
 
@@ -284,7 +295,7 @@ rationale:
 The bump goes in the same PR as the change. A "version-only bump" PR
 is not a thing — it always accompanies a content edit.
 
-### Components without a `provenance:` block
+### Components without a `metadata.provenance:` block
 
 Components shipped before the provenance contract existed (or
 intentionally unscoped) build unchanged — the resolver only acts on

--- a/community-config/agents/architect/AGENT.md
+++ b/community-config/agents/architect/AGENT.md
@@ -3,10 +3,11 @@ name: architect
 description: "Generic architecture agent. Drafts ADRs, runs design reviews,
   proposes alternatives with explicit trade-offs, and maps blast radius."
 type: agent
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 ---
 
 # Architect Agent

--- a/community-config/agents/developer/AGENT.md
+++ b/community-config/agents/developer/AGENT.md
@@ -3,10 +3,11 @@ name: developer
 description: "Generic implementation agent. Writes, edits, and refactors code
   with the smallest correct change. Verifies locally before reporting done."
 type: agent
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 ---
 
 # Developer Agent

--- a/community-config/agents/doc-writer/AGENT.md
+++ b/community-config/agents/doc-writer/AGENT.md
@@ -4,10 +4,11 @@ description: "Generic documentation agent. Drafts ADRs, READMEs, in-code
   docstrings, and reference material. Optimises for documents that age well
   and stays close to the code where possible."
 type: agent
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 ---
 
 # Doc Writer Agent

--- a/community-config/agents/harness-curator/AGENT.md
+++ b/community-config/agents/harness-curator/AGENT.md
@@ -5,10 +5,11 @@ description: "Generic harness-curator agent. On-demand reader of the global
   issue per cluster against the canonical/feedback repos. The fix MR lands
   later (human-authored or via auto-fix mode #42)."
 type: agent
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 ---
 
 # Harness Curator Agent

--- a/community-config/agents/pr-logbook/AGENT.md
+++ b/community-config/agents/pr-logbook/AGENT.md
@@ -4,10 +4,11 @@ description: "Generic PR and logbook composer agent. Drafts titles, bodies,
   test plans, logbook entries, and squash-merge commit messages that conform
   to the project's AGENTS.md conventions."
 type: agent
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 ---
 
 # PR & Logbook Agent

--- a/community-config/agents/security/AGENT.md
+++ b/community-config/agents/security/AGENT.md
@@ -4,10 +4,11 @@ description: "Generic security review agent. Threat modeling, secret hygiene,
   realistic-threat code review, dependency audit. Findings only — does not
   implement fixes unless explicitly asked."
 type: agent
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 ---
 
 # Security Agent

--- a/community-config/agents/tester/AGENT.md
+++ b/community-config/agents/tester/AGENT.md
@@ -4,10 +4,11 @@ description: "Generic test-authoring agent. Writes high-signal regression tests,
   enumerates priority edge cases, and verifies fixes by failing-then-passing
   the test against the bug."
 type: agent
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.0"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 ---
 
 # Tester Agent

--- a/community-config/skills/architect/SKILL.md
+++ b/community-config/skills/architect/SKILL.md
@@ -6,10 +6,11 @@ description: "Design and architecture skill for ADRs, RFCs, design reviews,
   the user explicitly asks for a design opinion or alternatives."
 type: skill
 license: Apache-2.0
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.4"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/ci-workflow-engineering/SKILL.md
+++ b/community-config/skills/ci-workflow-engineering/SKILL.md
@@ -7,10 +7,11 @@ description: "Structured approach for building, debugging, and hardening CI/CD
 type: skill
 license: Apache-2.0
 compatibility: "Requires the gh CLI (for fetching workflow runs and job logs) and bash. Optional: act for local workflow execution."
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/developer/SKILL.md
+++ b/community-config/skills/developer/SKILL.md
@@ -7,10 +7,11 @@ description: "Implementation skill for writing, modifying, and refactoring
 type: skill
 license: Apache-2.0
 compatibility: "Requires bash (used by scripts/build-components.sh) and git (used for staged-file inspection of executable bits)."
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.3"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/doc-writer/SKILL.md
+++ b/community-config/skills/doc-writer/SKILL.md
@@ -6,10 +6,11 @@ description: "Documentation skill for ADRs, READMEs, in-code docstrings, and
   architect skill's output. Optimised for documents that age well."
 type: skill
 license: Apache-2.0
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/harness-curator/SKILL.md
+++ b/community-config/skills/harness-curator/SKILL.md
@@ -8,10 +8,11 @@ description: "Harness feedback-loop curator. Activate on demand to read
 type: skill
 license: Apache-2.0
 compatibility: Requires bash, jq, the gh CLI (used by setup-labels.sh and --apply), and the mempalace Python package (pipx install 'mempalace>=3.3.3,<3.4').
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.1.1"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.2.0"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/harness-report/SKILL.md
+++ b/community-config/skills/harness-report/SKILL.md
@@ -6,10 +6,11 @@ description: "Tag a friction encountered during real work. Activate the moment
   the friction-tagging protocol — all other skills point here."
 type: skill
 license: Apache-2.0
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.2"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -7,10 +7,11 @@ description: "Pull request and logbook composer. Activate when opening a PR,
 type: skill
 license: Apache-2.0
 compatibility: "Requires git (for log and staged-file inspection), the gh CLI (for PR creation and logbook issue updates), and bash."
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.5"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/security/SKILL.md
+++ b/community-config/skills/security/SKILL.md
@@ -6,10 +6,11 @@ description: "Security review skill for threat modeling, dependency audit,
   parsing, deserialization, network calls, or upgrades to dependencies."
 type: skill
 license: Apache-2.0
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 claude:
   allowed-tools:
     - Read

--- a/community-config/skills/tester/SKILL.md
+++ b/community-config/skills/tester/SKILL.md
@@ -6,10 +6,11 @@ description: "Test authoring and test-strategy skill. Activate when writing
   high-signal tests that catch regressions, not coverage theatre."
 type: skill
 license: Apache-2.0
-provenance:
-  canonical: "${CANONICAL_REPO}"
-  feedback: "${FEEDBACK_REPO}"
-  version: "1.0.1"
+metadata:
+  provenance:
+    canonical: "${CANONICAL_REPO}"
+    feedback: "${FEEDBACK_REPO}"
+    version: "1.1.0"
 claude:
   allowed-tools:
     - Read

--- a/scripts/build-components.sh
+++ b/scripts/build-components.sh
@@ -95,31 +95,45 @@ validate_canonical_repo() {
 validate_canonical_repo
 
 # --- Provenance propagation ---
-# Components may declare a `provenance:` block in their source frontmatter.
-# This block must travel to every output that supports YAML frontmatter, so
-# installers and the harness curator can read where the component came from.
-# The build only natively copies name+description, so we inject provenance
-# explicitly at the bottom of the output frontmatter.
+# Components may declare a `metadata.provenance:` block in their source
+# frontmatter. This block must travel to every output that supports YAML
+# frontmatter, so installers and the harness curator can read where the
+# component came from. The build only natively copies name+description, so we
+# inject the `metadata:` wrapper explicitly at the bottom of the output
+# frontmatter.
+#
+# Schema note: provenance lives under `metadata:` to keep the root
+# frontmatter restricted to fields recognised by the agentskills.io spec
+# (`name`, `description`, `license`, `compatibility`, `metadata`,
+# `allowed-tools`).
 
-# Returns the provenance YAML block ready to splice into a frontmatter, or
-# empty if `frontmatter` (already extracted) has no `provenance:` key.
+# Returns the YAML block (top-level `metadata:` with a nested `provenance:`)
+# ready to splice into a frontmatter, or empty if `frontmatter` (already
+# extracted) has no `metadata.provenance` key.
 # Takes the frontmatter as input so callers can reuse a single extraction.
 provenance_block() {
   local frontmatter="$1"
   local has_prov
-  has_prov=$(printf '%s\n' "$frontmatter" | yq -r 'has("provenance")' 2>/dev/null || echo "false")
+  has_prov=$(printf '%s\n' "$frontmatter" | yq -r '.metadata // {} | has("provenance")' 2>/dev/null || echo "false")
   if [ "$has_prov" != "true" ]; then
     return 0
   fi
-  printf 'provenance:\n'
+  printf 'metadata:\n'
+  printf '  provenance:\n'
   printf '%s\n' "$frontmatter" \
-    | yq -r '.provenance | to_entries | .[] | "  " + .key + ": \"" + .value + "\""' 2>/dev/null
+    | yq -r '.metadata.provenance | to_entries | .[] | "    " + .key + ": \"" + .value + "\""' 2>/dev/null
 }
 
 # Splice a provenance block before the closing `---` of the first frontmatter
 # of `content`. No-op if the source has no provenance.
 # Uses a tempfile to feed multi-line provenance into awk — BSD awk does not
 # accept newlines in `-v var=...`, so we read the block via getline instead.
+#
+# Coordination note: the spliced block emits a full top-level `metadata:`
+# key (with `provenance:` nested under it). If a future build path also
+# needs to emit `metadata.*` fields into the output frontmatter, it must
+# merge with this splice rather than emit a second `metadata:` key — YAML
+# does not allow duplicate top-level mappings.
 inject_provenance() {
   local content="$1"
   local source="$2"

--- a/scripts/check-skill-versions.sh
+++ b/scripts/check-skill-versions.sh
@@ -4,7 +4,8 @@
 # Per community-config/FORMAT.md → Version semantics, every PR that touches
 # a `community-config/skills/<name>/SKILL.md` or
 # `community-config/agents/<name>/AGENT.md` source MUST bump
-# `provenance.version` in the same diff. This script enforces the rule.
+# `metadata.provenance.version` in the same diff. This script enforces the
+# rule.
 #
 # Usage:
 #   bash scripts/check-skill-versions.sh [<base-ref>]
@@ -56,15 +57,15 @@ failures=()
 for f in "${changed[@]}"; do
   [ ! -f "$f" ] && continue  # deleted file: skip (deletions don't need a bump)
 
-  # Look at the diff for a `version:` line addition. The provenance.version
-  # field is indented under `provenance:` so the line typically reads
-  # `  version: "X.Y.Z"`. We match any added line whose trimmed text starts
-  # with `version:` — covers both the indented form and a hypothetical
-  # top-level placement.
+  # Look at the diff for a `version:` line addition. The
+  # metadata.provenance.version field is nested under `metadata:` →
+  # `provenance:` so the line typically reads `    version: "X.Y.Z"`
+  # (indent 4). We match any added line whose trimmed text starts with
+  # `version:` — covers the nested form and any hypothetical placement.
   if git diff "$BASE_REF" -- "$f" | grep -qE '^\+[[:space:]]+version:[[:space:]]*"'; then
     echo "  OK   $f"
   else
-    echo "  FAIL $f — provenance.version not bumped"
+    echo "  FAIL $f — metadata.provenance.version not bumped"
     failures+=("$f")
   fi
 done
@@ -77,7 +78,7 @@ if [ "${#failures[@]}" -gt 0 ]; then
   done
   echo ""
   echo "Per community-config/FORMAT.md → Version semantics, bump"
-  echo "provenance.version in the same diff. SemVer:"
+  echo "metadata.provenance.version in the same diff. SemVer:"
   echo "  PATCH (1.0.0 → 1.0.1) — friction fix / wording change"
   echo "  MINOR (1.0.0 → 1.1.0) — additive (new section, new field)"
   echo "  MAJOR (1.0.0 → 2.0.0) — breaking contract change"


### PR DESCRIPTION
Move the `provenance:` block from the frontmatter root into `metadata.provenance:` across all 9 skills and 7 agents, aligning CrewRig with the agentskills.io frontmatter spec. The build pipeline (`scripts/build-components.sh`) is updated to emit the nested structure, and bundles under `.claude/` and `.gemini/` are regenerated to match.

Closes #54.

## How to read this PR?

Suggested reading order:

1. **`community-config/FORMAT.md`** — the documented contract; read first to see the new shape (`metadata.provenance.{canonical,feedback,version}`).
2. **`scripts/build-components.sh`** — focus on `inject_provenance()`. The comment there is intentional: it coordinates *future* emitters of `metadata.*` keys, which will need to merge under the existing `metadata:` block rather than duplicate it. Worth noting for downstream work.
3. **`community-config/skills/*/SKILL.md` + `community-config/agents/*/AGENT.md`** — 16 source files migrated; all now expose a top-level `metadata:` block with `provenance:` nested under it.
4. **`.claude/` and `.gemini/` bundles** — purely the output of `bash scripts/build-components.sh` against the migrated sources; no hand edits.

Non-obvious decisions:

- The migration keeps `canonical`, `feedback`, and `version` field names identical — only the nesting level changes. Consumers reading `metadata.provenance.canonical` get the same string they used to read at `provenance.canonical`.
- Bundles are committed (rather than regenerated downstream) to keep `.claude/` and `.gemini/` browseable without a build step, consistent with the existing repo layout.

## How to test this PR?

Prerequisites: `bash`, `yq`, `git`.

```bash
# 1. No remaining root-level provenance keys anywhere
grep -rn "^provenance:" community-config/ .claude/ .gemini/
# Expected: no output, exit 1

# 2. Every source carries the new metadata block
grep -l "^metadata:" community-config/skills/*/SKILL.md community-config/agents/*/AGENT.md | wc -l
# Expected: 16

# 3. Spot-check a bundle's frontmatter shape
sed -n '1,/^---$/p; /^---$/,/^---$/p' .claude/skills/harness-curator/SKILL.md | head -40
# Expected: metadata: → provenance: → canonical/feedback/version (version 1.2.0)

# 4. Idempotent rebuild — no drift between sources and bundles
bash scripts/build-components.sh
git diff --exit-code .claude .gemini
# Expected: exit 0
```

## Detailed description (for agents)

**Scope.** Frontmatter migration for V0 skills and agents, plus the build script and format documentation. No runtime/behavioral logic changed; this is a structural relocation of metadata keys.

**Source files migrated (16 total).**

- 9 skills under `community-config/skills/`: `architect`, `developer`, `doc-writer`, `harness-curator`, `harness-report`, `pr-logbook`, `security`, `tester`, plus the meta-skill carrying provenance.
- 7 agents under `community-config/agents/`: `architect`, `developer`, `doc-writer`, `harness-curator`, `pr-logbook`, `security`, `tester`.

Each file's frontmatter changed from:

```yaml
provenance:
  canonical: ...
  feedback: ...
  version: ...
```

to:

```yaml
metadata:
  provenance:
    canonical: ...
    feedback: ...
    version: ...
```

**Build script (`scripts/build-components.sh`).** The `inject_provenance()` helper now writes the nested `metadata.provenance.*` structure when materializing bundles. An inline comment flags the forward-compatibility constraint: any future emitter of `metadata.<other-key>` MUST merge under the existing `metadata:` block rather than redeclare it, otherwise the bundle ends up with duplicate top-level `metadata:` keys (invalid YAML in strict parsers).

**Documentation (`community-config/FORMAT.md`).** Updated to reflect the nested shape as the contract.

**Bundles (`.claude/`, `.gemini/`).** Regenerated by running `bash scripts/build-components.sh` against the migrated sources. The second commit (`f3bc3cc`) contains only the bundle diff and is the deterministic output of the first commit's sources + script.

**Verification (5/5 PASS, performed by the tester agent).**

1. `grep -rn "^provenance:"` on `community-config/`, `.claude/`, `.gemini/` returns empty (exit 1) — no root-level `provenance:` remains.
2. All 16 source files expose a root-level `metadata:` block.
3. Spot-checks on bundles confirm correct indentation: `.claude/skills/harness-curator/SKILL.md` (v1.2.0), `.gemini/skills/developer/SKILL.md` (v1.1.0), `.claude/agents/architect/AGENT.md` (v1.1.0).
4. `bash scripts/build-components.sh` runs cleanly; `git diff --exit-code .claude .gemini` returns 0 — the build is idempotent against the committed sources.
5. Post-rebuild re-verification: no `^provenance:` remains in regenerated bundles.

**Known technical debt (non-blocking, predates this PR).** `yq` emits a warning `did not find expected <document start>` on some sources whose body contains a `---` separator (e.g. `developer`). The read value is correct in all observed cases. Tracking this as observed-but-deferred rather than expanding the scope of this PR.

**Commits.**

- `088a3a0` — `♻️ Move provenance under metadata for agentskills.io spec compliance` (sources + script + FORMAT.md).
- `f3bc3cc` — `🔨 Rebuild bundles with metadata.provenance frontmatter` (deterministic rebuild output).
