### PR TITLE
♻️ Migrate SKELETON_NAME literals to ${SKELETON_NAME} placeholders

### DIFF
--- a/extension-skeleton/agent/agents/sample-agent/PROMPT.md
+++ b/extension-skeleton/agent/agents/sample-agent/PROMPT.md
@@ -1,9 +1,9 @@
-# SKELETON_NAME Sub-Agent
+# ${SKELETON_NAME} Sub-Agent
 
-You are a specialized sub-agent for the SKELETON_NAME extension.
+You are a specialized sub-agent for the ${SKELETON_NAME} extension.
 Handle delegated sub-tasks and report results back to the orchestrator.
 
 ## Scope
 
-- Stay within SKELETON_NAME responsibilities.
+- Stay within ${SKELETON_NAME} responsibilities.
 - Be concise and technical in your responses.

--- a/extension-skeleton/base/CLAUDE.md
+++ b/extension-skeleton/base/CLAUDE.md
@@ -1,4 +1,4 @@
-# SKELETON_NAME Extension
+# ${SKELETON_NAME} Extension
 
 Context file loaded when this extension is active in Claude Code.
 

--- a/extension-skeleton/base/GEMINI.md
+++ b/extension-skeleton/base/GEMINI.md
@@ -1,6 +1,6 @@
-# SKELETON_NAME Context
+# ${SKELETON_NAME} Context
 
-Loaded when the SKELETON_NAME extension is active. Describes the
+Loaded when the ${SKELETON_NAME} extension is active. Describes the
 extension's purpose and available capabilities to the agent.
 
 ## Capabilities

--- a/extension-skeleton/base/README.md
+++ b/extension-skeleton/base/README.md
@@ -1,11 +1,11 @@
-# SKELETON_NAME Extension
+# ${SKELETON_NAME} Extension
 
 Brief description of what this extension does.
 
 ## Installation
 
 ```bash
-task install-extension EXT=SKELETON_NAME
+task install-extension EXT=${SKELETON_NAME}
 ```
 
 ## Structure

--- a/extension-skeleton/base/extension.json
+++ b/extension-skeleton/base/extension.json
@@ -1,7 +1,7 @@
 {
-  "name": "SKELETON_NAME",
+  "name": "${SKELETON_NAME}",
   "version": "0.1.0",
-  "description": "Description of the SKELETON_NAME extension.",
+  "description": "Description of the ${SKELETON_NAME} extension.",
   "components": {
     "commands": {
       "enabled": false,

--- a/extension-skeleton/base/gemini-extension.json
+++ b/extension-skeleton/base/gemini-extension.json
@@ -1,6 +1,6 @@
 {
-  "name": "SKELETON_NAME",
+  "name": "${SKELETON_NAME}",
   "version": "0.1.0",
-  "description": "Description of the SKELETON_NAME extension.",
+  "description": "Description of the ${SKELETON_NAME} extension.",
   "contextFileName": "GEMINI.md"
 }

--- a/extension-skeleton/base/package.json
+++ b/extension-skeleton/base/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "SKELETON_NAME-extension",
+  "name": "${SKELETON_NAME}-extension",
   "version": "0.1.0",
   "type": "module",
   "main": "dist/index.js",

--- a/extension-skeleton/command/commands/sample.toml
+++ b/extension-skeleton/command/commands/sample.toml
@@ -1,2 +1,2 @@
-description = "Sample command for SKELETON_NAME"
-prompt = "This is a placeholder prompt from the SKELETON_NAME extension. Replace with your own logic."
+description = "Sample command for ${SKELETON_NAME}"
+prompt = "This is a placeholder prompt from the ${SKELETON_NAME} extension. Replace with your own logic."

--- a/extension-skeleton/hook/hooks/hooks.json
+++ b/extension-skeleton/hook/hooks/hooks.json
@@ -3,7 +3,7 @@
     {
       "event": "BeforeTool",
       "matcher": "*",
-      "name": "SKELETON_NAME-logger",
+      "name": "${SKELETON_NAME}-logger",
       "type": "command",
       "command": "bash ${extensionPath}/hooks/logger.sh"
     }

--- a/extension-skeleton/hook/hooks/logger.sh
+++ b/extension-skeleton/hook/hooks/logger.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Hook: SKELETON_NAME logger
+# Hook: ${SKELETON_NAME} logger
 # Intercepts tool calls. Modify or validate the payload as needed.
 
 read -r PAYLOAD

--- a/extension-skeleton/mcp-server/src/index.ts
+++ b/extension-skeleton/mcp-server/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 const server = new Server(
-  { name: "SKELETON_NAME", version: "0.1.0" },
+  { name: "${SKELETON_NAME}", version: "0.1.0" },
   { capabilities: { tools: {} } }
 );
 
@@ -41,6 +41,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 const transport = new StdioServerTransport();
 server.connect(transport).catch((err) => {
-  console.error("Failed to start SKELETON_NAME MCP server:", err);
+  console.error("Failed to start ${SKELETON_NAME} MCP server:", err);
   process.exit(1);
 });

--- a/extension-skeleton/skill/skills/sample-skill/SKILL.md
+++ b/extension-skeleton/skill/skills/sample-skill/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: SKELETON_NAME:sample-skill
-description: "Activate when the user needs SKELETON_NAME-specific assistance."
+name: ${SKELETON_NAME}:sample-skill
+description: "Activate when the user needs ${SKELETON_NAME}-specific assistance."
 ---
 
-# SKELETON_NAME Sample Skill
+# ${SKELETON_NAME} Sample Skill
 
 Replace this content with the actual skill workflow.
 

--- a/extension-skeleton/theme/theme.json.fragment
+++ b/extension-skeleton/theme/theme.json.fragment
@@ -2,7 +2,7 @@
   "gemini": {
     "themes": [
       {
-        "name": "SKELETON_NAME-dark",
+        "name": "${SKELETON_NAME}-dark",
         "colors": {
           "primary": "#00adb5",
           "secondary": "#ff2e63",

--- a/scripts/create-extension.sh
+++ b/scripts/create-extension.sh
@@ -51,7 +51,7 @@ done <<< "$COMPONENTS"
 # --- Replace SKELETON_NAME placeholder ---
 find "$TARGET" -type f | while read -r file; do
   if file "$file" | grep -q text; then
-    sed -i.bak "s/SKELETON_NAME/$NAME/g" "$file"
+    sed -i.bak "s/\${SKELETON_NAME}/$NAME/g" "$file"
     rm -f "$file.bak"
   fi
 done

--- a/scripts/create-extension.sh
+++ b/scripts/create-extension.sh
@@ -48,7 +48,7 @@ while IFS= read -r comp; do
   fi
 done <<< "$COMPONENTS"
 
-# --- Replace SKELETON_NAME placeholder ---
+# --- Replace ${SKELETON_NAME} placeholder ---
 find "$TARGET" -type f | while read -r file; do
   if file "$file" | grep -q text; then
     sed -i.bak "s/\${SKELETON_NAME}/$NAME/g" "$file"


### PR DESCRIPTION
Migrate every `SKELETON_NAME` literal in the extension skeleton tree to the explicit `${SKELETON_NAME}` placeholder form, and align `scripts/create-extension.sh` accordingly. The new form is unambiguous, makes substitution intent explicit at the call site, and removes the risk of false-positive matches on substrings.

closes #44

## How to read this PR?

1. Start with `scripts/create-extension.sh` — the sed pattern at L54 is the contract that drives every skeleton file. Note the section comment at L51 was also updated to `${SKELETON_NAME}` for stylistic consistency (commit `80f8af6`).
2. Walk the 13 modified files under `extension-skeleton/` in any order — they all apply the same mechanical substitution. Suggested entry points: `base/gemini-extension.json`, `base/package.json`, then the per-component skeletons (`skill/`, `mcp-server/`, `agent/`, `command/`, `hook/`, `theme/`).
3. `.geminiignore` is intentionally untouched: it contained no `SKELETON_NAME` token.

## How to test this PR?

Prerequisites: a checkout of this branch.

```bash
# 1. No bare SKELETON_NAME literals remain in skeleton or script (excluding ${...} form)
grep -r "SKELETON_NAME" extension-skeleton/ scripts/create-extension.sh \
  | grep -v '\${SKELETON_NAME}'
# Expected: 0 hit

# 2. All occurrences use the placeholder form
grep -rc "\${SKELETON_NAME}" extension-skeleton/
# Expected: 13 files, 23 occurrences total

# 3. The sed pattern in the generator matches the placeholder form
grep -n 'SKELETON_NAME' scripts/create-extension.sh
# Expected at L54: sed -i.bak "s/\${SKELETON_NAME}/$NAME/g" "$file"

# 4. Dry-run the substitution
echo 'Hello ${SKELETON_NAME}' | sed "s/\${SKELETON_NAME}/my-ext/g"
# Expected: Hello my-ext
```

All four checks pass on this branch (verified by the tester).

## Detailed description (for agents)

**Scope.** 14 files modified across two areas:

- `extension-skeleton/` (13 files):
  - `base/`: `README.md`, `gemini-extension.json`, `package.json`, `GEMINI.md`, `extension.json`, `CLAUDE.md`
  - `skill/skills/sample-skill/SKILL.md`
  - `mcp-server/src/index.ts`
  - `agent/agents/sample-agent/PROMPT.md`
  - `command/commands/sample.toml`
  - `hook/hooks/hooks.json`, `hook/hooks/logger.sh`
  - `theme/theme.json.fragment`
- `scripts/` (1 file):
  - `create-extension.sh` — sed pattern at L54 changed from `s/SKELETON_NAME/.../g` to `s/\${SKELETON_NAME}/.../g`; section comment at L51 updated to `${SKELETON_NAME}` for stylistic alignment.

**Why `${SKELETON_NAME}` over `SKELETON_NAME`.** The bare literal would match any occurrence of the substring across skeleton files — including documentation, comments, or future code that might mention the token for legitimate reasons. The `${...}` form is unambiguous as a placeholder, mirrors shell-style variable interpolation that readers already recognize, and removes the entire class of accidental substitutions. The generator's sed pattern escapes the `$` and braces so the literal token is matched, not a shell-expanded variable.

**Commits.**

- `8b43db1` — ♻️ Migrate SKELETON_NAME literals to ${SKELETON_NAME} placeholders (#44)
- `80f8af6` — ♻️ Update section comment to ${SKELETON_NAME} for consistency (#44)

The second commit landed after a tester round-trip: a section comment at L51 of `create-extension.sh` still carried the bare literal. No runtime impact, fixed for stylistic consistency.

**Non-scope.** `.geminiignore` was inspected and contained only `*` — no `SKELETON_NAME` token, so no change was needed.

**Count reconciliation.** The original brief estimated 14 files / 22 occurrences; the verified count is 13 skeleton files + 1 script = 14 modified files total, 23 placeholder occurrences in the skeleton tree. The 14-file total matches; the per-tree breakdown was off by one and the occurrence count by one. No functional impact.