### PR TITLE
✨ Add --deep mode to Harness Curator for transcript sweep

### DIFF
--- a/.claude/skills/harness-curator/SKILL.md
+++ b/.claude/skills/harness-curator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-curator
-description: "Harness feedback-loop curator. Activate on demand to read friction tags from the global harness-friction wing, cluster them, and open one descriptive issue per cluster on the canonical/feedback repos declared in components' provenance blocks. The fix MR lands later (human-authored or via the auto-fix mode tracked in #42)."
+description: "Harness feedback-loop curator. Activate on demand to read friction tags from the global harness-friction wing, cluster them, and open one descriptive issue per cluster on the canonical/feedback repos declared in components' provenance blocks. The fix MR lands later (human-authored or via the auto-fix mode tracked in #42). Also supports a `--deep` mode that sweeps `wing=transcripts` with heuristic pre-filtering and emits a Markdown review document for triage."
 license: Apache-2.0
 compatibility: "Requires bash, jq, the gh CLI (used by setup-labels.sh and --apply), and the mempalace Python package (pipx install 'mempalace>=3.3.3,<3.4')."
 allowed-tools:
@@ -13,7 +13,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 
@@ -158,9 +158,35 @@ If `--apply` fails on a missing label, the script surfaces it as a
 `failures:` entry in the run summary. The maintainer creates the
 label and retries.
 
-`--deep` mode (sweep `wing="transcripts"` for unflagged friction
-patterns) is **out of V0 scope** — tracked in issue #43. Auto mode is
-tracked in issue #42.
+### --deep mode
+
+Run a heuristic sweep of `wing="transcripts"` instead of the regular
+`wing="harness-friction"` curation. Useful for catching frictions that
+slipped through the recognition signals and were never tagged.
+
+```bash
+bash scripts/curate.sh --deep
+# Tune the scan window (default: 500 most-recent transcript drawers):
+bash scripts/curate.sh --deep --deep-window 1000
+```
+
+Behavior:
+
+- Reads up to `--deep-window` drawers from `wing="transcripts"` (most
+  recent first).
+- Pre-filters each drawer against a fixed set of heuristic regex
+  patterns (`error`, `failed`, `retry`, `not working`, `unexpected`,
+  `broken`, `didn't work`, `try again`).
+- Emits a **Markdown review document** on stdout — not JSON, not
+  issues. Each candidate appears as a checkbox item grouped by pattern,
+  with a one-line excerpt for triage.
+- Incompatible with `--apply`: the script exits with an error if both
+  are passed. Deep mode is a discovery aid, not an issue-opening path.
+  To promote a candidate, the human (or agent) runs `/harness-report`
+  for it, which lands a `FRICTION:` payload in `wing="harness-friction"`
+  for the next regular sweep.
+
+Auto mode is tracked in issue #42.
 
 ### 5. Run summary
 

--- a/.claude/skills/harness-curator/scripts/curate.py
+++ b/.claude/skills/harness-curator/scripts/curate.py
@@ -66,6 +66,20 @@ WING = os.environ.get("FRICTION_WING", "harness-friction")
 THRESHOLD = int(os.environ.get("THRESHOLD", "2"))
 TARGET_OVERRIDE = os.environ.get("TARGET_REPO_OVERRIDE", "").strip()
 STDIN_FILE = os.environ.get("FROM_STDIN_FILE", "").strip()
+DEEP_MODE = os.environ.get("DEEP_MODE", "false").lower() == "true"
+DEEP_WINDOW = int(os.environ.get("DEEP_WINDOW", "500"))
+
+# Heuristic keyword patterns for --deep pre-filter (label → regex)
+_DEEP_HEURISTICS: Dict[str, str] = {
+    "FAILED":        r"\bfailed\b",
+    "error":         r"\berror\b",
+    "retry":         r"\bretry\b",
+    "didn't work":   r"didn.t work",
+    "not working":   r"not working",
+    "unexpected":    r"\bunexpected\b",
+    "broken":        r"\bbroken\b",
+    "try again":     r"try again",
+}
 
 # Keep the page size aligned with prune-transcripts.sh: 100 is the sweet spot
 # between MCP roundtrips and per-call payload size.
@@ -413,10 +427,131 @@ def cluster_labels(cluster: List[Dict[str, Any]]) -> List[str]:
     ]
 
 
+# --- Deep mode ------------------------------------------------------------
+
+
+def read_transcripts_window(window: int) -> List[Dict[str, Any]]:
+    """Read at most `window` drawers from wing=transcripts (most recent first)."""
+    try:
+        from mempalace.mcp_server import tool_get_drawer, tool_list_drawers
+    except ImportError as e:
+        print(f"Error: failed to import mempalace ({e}).", file=sys.stderr)
+        sys.exit(2)
+    drawers: List[Dict[str, Any]] = []
+    offset = 0
+    while len(drawers) < window:
+        page_size = min(PAGE_SIZE, window - len(drawers))
+        page = tool_list_drawers(wing="transcripts", limit=page_size, offset=offset)
+        batch = page.get("drawers", [])
+        if not batch:
+            break
+        for stub in batch:
+            did = stub.get("drawer_id")
+            if not did:
+                continue
+            full = tool_get_drawer(drawer_id=did)
+            drawers.append({
+                "drawer_id": did,
+                "room": full.get("room", "") or stub.get("room", ""),
+                "content": full.get("content", ""),
+                "filed_at": (full.get("metadata") or {}).get("filed_at", ""),
+            })
+        if len(batch) < page_size:
+            break
+        offset += page_size
+    return drawers
+
+
+def _deep_excerpt(content: str, pattern: str) -> str:
+    """Return the first line containing `pattern` (capped at 120 chars)."""
+    for line in content.splitlines():
+        if re.search(pattern, line, re.IGNORECASE):
+            excerpt = line.strip()
+            return excerpt[:120] + "…" if len(excerpt) > 120 else excerpt
+    return ""
+
+
+def compose_deep_review(
+    candidates: List[Dict[str, Any]],
+    total_scanned: int,
+    window: int,
+) -> str:
+    """Compose a Markdown review document from heuristic candidates."""
+    import datetime
+    today = datetime.date.today().isoformat()
+    by_pattern: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for c in candidates:
+        for pat_label in c["matched_patterns"]:
+            by_pattern[pat_label].append(c)
+
+    lines: List[str] = [
+        f"# Harness Deep Sweep — {today}",
+        "",
+        f"Scanned **{total_scanned}** drawers from `wing=transcripts` (window: {window}).",
+        f"Pre-filtered to **{len(candidates)}** candidate drawers matching heuristic patterns.",
+        "",
+        "> Tick the items you want to promote to real friction tags, then run `/harness-report`",
+        "> for each one to create a `FRICTION:` payload in `wing=harness-friction`.",
+        "",
+    ]
+    for pat_label, items in sorted(by_pattern.items(), key=lambda kv: -len(kv[1])):
+        pattern_re = _DEEP_HEURISTICS[pat_label]
+        lines.append(
+            f"## Pattern: `{pat_label}` "
+            f"({len(items)} occurrence{'s' if len(items) != 1 else ''})"
+        )
+        lines.append("")
+        shown = items[:20]
+        for item in shown:
+            date = item["filed_at"].split("T")[0] if item.get("filed_at") else "unknown"
+            lines.append(
+                f"- [ ] Drawer `{item['drawer_id']}` "
+                f"(room: `{item['room'] or '?'}`, date: {date})"
+            )
+            excerpt = _deep_excerpt(item["content"], pattern_re)
+            if excerpt:
+                lines.append(f"  > {excerpt}")
+        if len(items) > 20:
+            lines.append(f"  _({len(items) - 20} more occurrences not shown)_")
+        lines.append("")
+    lines += [
+        "## Next steps",
+        "",
+        "For each ticked item, run `/harness-report` to tag it as a `FRICTION:` payload "
+        "in `wing=harness-friction`. It will appear in the next regular curator sweep.",
+    ]
+    return "\n".join(lines)
+
+
 # --- Main -----------------------------------------------------------------
 
 
 def main() -> int:
+    if DEEP_MODE:
+        if STDIN_FILE:
+            try:
+                drawers = read_from_stdin_file()
+            except (OSError, ValueError) as e:
+                print(f"Error: failed to read stdin JSON: {e}", file=sys.stderr)
+                return 2
+        else:
+            drawers = read_transcripts_window(DEEP_WINDOW)
+        candidates = []
+        for drawer in drawers:
+            content = drawer.get("content", "")
+            matched = [
+                label
+                for label, pat in _DEEP_HEURISTICS.items()
+                if re.search(pat, content, re.IGNORECASE)
+            ]
+            if matched:
+                candidates.append({**drawer, "matched_patterns": matched})
+        review = compose_deep_review(candidates, len(drawers), DEEP_WINDOW)
+        _REAL_STDOUT.write(review)
+        _REAL_STDOUT.write("\n")
+        _REAL_STDOUT.flush()
+        return 0
+
     if STDIN_FILE:
         try:
             drawers = read_from_stdin_file()

--- a/.claude/skills/harness-curator/scripts/curate.sh
+++ b/.claude/skills/harness-curator/scripts/curate.sh
@@ -15,6 +15,7 @@
 #                          [--from-stdin]
 #                          [--target-repo <url>]
 #                          [--threshold <n>]
+#                          [--deep] [--deep-window <n>]
 #
 # Options:
 #   --dry-run        Output JSON of clusters that would become issues (default).
@@ -25,6 +26,11 @@
 #                    provenance routing). For tests / single-fork curation.
 #   --threshold      Minimum cluster size to propose an issue (default: 2).
 #                    Severity-`high` frictions bypass this and always cluster.
+#   --deep           Deep sweep mode: scan wing=transcripts with heuristic
+#                    pre-filtering and emit a Markdown review document
+#                    instead of clusters/issues. Incompatible with --apply.
+#   --deep-window    Maximum number of transcript drawers to scan in --deep
+#                    mode (default: 500).
 #
 # Environment:
 #   MEMPALACE_PYTHON Python binary with `mempalace` installed (auto-detected
@@ -42,6 +48,8 @@ DRY_RUN=true
 FROM_STDIN=false
 TARGET_REPO=""
 THRESHOLD=2
+DEEP_MODE=false
+DEEP_WINDOW=500
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -50,8 +58,10 @@ while [[ $# -gt 0 ]]; do
     --from-stdin)     FROM_STDIN=true; shift ;;
     --target-repo)    TARGET_REPO="$2"; shift 2 ;;
     --threshold)      THRESHOLD="$2"; shift 2 ;;
+    --deep)           DEEP_MODE=true; shift ;;
+    --deep-window)    DEEP_WINDOW="$2"; shift 2 ;;
     --help|-h)
-      sed -n '2,30p' "$0"
+      sed -n '2,33p' "$0"
       exit 0
       ;;
     *)
@@ -64,6 +74,11 @@ done
 
 if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]] || [ "$THRESHOLD" -lt 1 ]; then
   echo "Error: --threshold must be a positive integer" >&2
+  exit 1
+fi
+
+if [ "$DEEP_MODE" = true ] && [ "$DRY_RUN" = false ]; then
+  echo "Error: --deep is incompatible with --apply (--deep produces a review document only)." >&2
   exit 1
 fi
 
@@ -115,9 +130,16 @@ CURATE_OUT=$(env \
   THRESHOLD="$THRESHOLD" \
   TARGET_REPO_OVERRIDE="$TARGET_REPO" \
   FROM_STDIN_FILE="$STDIN_FILE" \
+  DEEP_MODE="$DEEP_MODE" \
+  DEEP_WINDOW="$DEEP_WINDOW" \
   "$MEMPALACE_PYTHON" "$(dirname "$0")/curate.py")
 
 # --- Output / apply ---
+if [ "$DEEP_MODE" = true ]; then
+  printf '%s\n' "$CURATE_OUT"
+  exit 0
+fi
+
 if [ "$DRY_RUN" = true ]; then
   printf '%s\n' "$CURATE_OUT"
   exit 0

--- a/.gemini/skills/harness-curator/SKILL.md
+++ b/.gemini/skills/harness-curator/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: harness-curator
-description: "Harness feedback-loop curator. Activate on demand to read friction tags from the global harness-friction wing, cluster them, and open one descriptive issue per cluster on the canonical/feedback repos declared in components' provenance blocks. The fix MR lands later (human-authored or via the auto-fix mode tracked in #42)."
+description: "Harness feedback-loop curator. Activate on demand to read friction tags from the global harness-friction wing, cluster them, and open one descriptive issue per cluster on the canonical/feedback repos declared in components' provenance blocks. The fix MR lands later (human-authored or via the auto-fix mode tracked in #42). Also supports a `--deep` mode that sweeps `wing=transcripts` with heuristic pre-filtering and emits a Markdown review document for triage."
 license: Apache-2.0
 compatibility: "Requires bash, jq, the gh CLI (used by setup-labels.sh and --apply), and the mempalace Python package (pipx install 'mempalace>=3.3.3,<3.4')."
 metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.2.0"
+    version: "1.3.0"
 ---
 
 
@@ -152,9 +152,35 @@ If `--apply` fails on a missing label, the script surfaces it as a
 `failures:` entry in the run summary. The maintainer creates the
 label and retries.
 
-`--deep` mode (sweep `wing="transcripts"` for unflagged friction
-patterns) is **out of V0 scope** — tracked in issue #43. Auto mode is
-tracked in issue #42.
+### --deep mode
+
+Run a heuristic sweep of `wing="transcripts"` instead of the regular
+`wing="harness-friction"` curation. Useful for catching frictions that
+slipped through the recognition signals and were never tagged.
+
+```bash
+bash scripts/curate.sh --deep
+# Tune the scan window (default: 500 most-recent transcript drawers):
+bash scripts/curate.sh --deep --deep-window 1000
+```
+
+Behavior:
+
+- Reads up to `--deep-window` drawers from `wing="transcripts"` (most
+  recent first).
+- Pre-filters each drawer against a fixed set of heuristic regex
+  patterns (`error`, `failed`, `retry`, `not working`, `unexpected`,
+  `broken`, `didn't work`, `try again`).
+- Emits a **Markdown review document** on stdout — not JSON, not
+  issues. Each candidate appears as a checkbox item grouped by pattern,
+  with a one-line excerpt for triage.
+- Incompatible with `--apply`: the script exits with an error if both
+  are passed. Deep mode is a discovery aid, not an issue-opening path.
+  To promote a candidate, the human (or agent) runs `/harness-report`
+  for it, which lands a `FRICTION:` payload in `wing="harness-friction"`
+  for the next regular sweep.
+
+Auto mode is tracked in issue #42.
 
 ### 5. Run summary
 

--- a/.gemini/skills/harness-curator/scripts/curate.py
+++ b/.gemini/skills/harness-curator/scripts/curate.py
@@ -66,6 +66,20 @@ WING = os.environ.get("FRICTION_WING", "harness-friction")
 THRESHOLD = int(os.environ.get("THRESHOLD", "2"))
 TARGET_OVERRIDE = os.environ.get("TARGET_REPO_OVERRIDE", "").strip()
 STDIN_FILE = os.environ.get("FROM_STDIN_FILE", "").strip()
+DEEP_MODE = os.environ.get("DEEP_MODE", "false").lower() == "true"
+DEEP_WINDOW = int(os.environ.get("DEEP_WINDOW", "500"))
+
+# Heuristic keyword patterns for --deep pre-filter (label → regex)
+_DEEP_HEURISTICS: Dict[str, str] = {
+    "FAILED":        r"\bfailed\b",
+    "error":         r"\berror\b",
+    "retry":         r"\bretry\b",
+    "didn't work":   r"didn.t work",
+    "not working":   r"not working",
+    "unexpected":    r"\bunexpected\b",
+    "broken":        r"\bbroken\b",
+    "try again":     r"try again",
+}
 
 # Keep the page size aligned with prune-transcripts.sh: 100 is the sweet spot
 # between MCP roundtrips and per-call payload size.
@@ -413,10 +427,131 @@ def cluster_labels(cluster: List[Dict[str, Any]]) -> List[str]:
     ]
 
 
+# --- Deep mode ------------------------------------------------------------
+
+
+def read_transcripts_window(window: int) -> List[Dict[str, Any]]:
+    """Read at most `window` drawers from wing=transcripts (most recent first)."""
+    try:
+        from mempalace.mcp_server import tool_get_drawer, tool_list_drawers
+    except ImportError as e:
+        print(f"Error: failed to import mempalace ({e}).", file=sys.stderr)
+        sys.exit(2)
+    drawers: List[Dict[str, Any]] = []
+    offset = 0
+    while len(drawers) < window:
+        page_size = min(PAGE_SIZE, window - len(drawers))
+        page = tool_list_drawers(wing="transcripts", limit=page_size, offset=offset)
+        batch = page.get("drawers", [])
+        if not batch:
+            break
+        for stub in batch:
+            did = stub.get("drawer_id")
+            if not did:
+                continue
+            full = tool_get_drawer(drawer_id=did)
+            drawers.append({
+                "drawer_id": did,
+                "room": full.get("room", "") or stub.get("room", ""),
+                "content": full.get("content", ""),
+                "filed_at": (full.get("metadata") or {}).get("filed_at", ""),
+            })
+        if len(batch) < page_size:
+            break
+        offset += page_size
+    return drawers
+
+
+def _deep_excerpt(content: str, pattern: str) -> str:
+    """Return the first line containing `pattern` (capped at 120 chars)."""
+    for line in content.splitlines():
+        if re.search(pattern, line, re.IGNORECASE):
+            excerpt = line.strip()
+            return excerpt[:120] + "…" if len(excerpt) > 120 else excerpt
+    return ""
+
+
+def compose_deep_review(
+    candidates: List[Dict[str, Any]],
+    total_scanned: int,
+    window: int,
+) -> str:
+    """Compose a Markdown review document from heuristic candidates."""
+    import datetime
+    today = datetime.date.today().isoformat()
+    by_pattern: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for c in candidates:
+        for pat_label in c["matched_patterns"]:
+            by_pattern[pat_label].append(c)
+
+    lines: List[str] = [
+        f"# Harness Deep Sweep — {today}",
+        "",
+        f"Scanned **{total_scanned}** drawers from `wing=transcripts` (window: {window}).",
+        f"Pre-filtered to **{len(candidates)}** candidate drawers matching heuristic patterns.",
+        "",
+        "> Tick the items you want to promote to real friction tags, then run `/harness-report`",
+        "> for each one to create a `FRICTION:` payload in `wing=harness-friction`.",
+        "",
+    ]
+    for pat_label, items in sorted(by_pattern.items(), key=lambda kv: -len(kv[1])):
+        pattern_re = _DEEP_HEURISTICS[pat_label]
+        lines.append(
+            f"## Pattern: `{pat_label}` "
+            f"({len(items)} occurrence{'s' if len(items) != 1 else ''})"
+        )
+        lines.append("")
+        shown = items[:20]
+        for item in shown:
+            date = item["filed_at"].split("T")[0] if item.get("filed_at") else "unknown"
+            lines.append(
+                f"- [ ] Drawer `{item['drawer_id']}` "
+                f"(room: `{item['room'] or '?'}`, date: {date})"
+            )
+            excerpt = _deep_excerpt(item["content"], pattern_re)
+            if excerpt:
+                lines.append(f"  > {excerpt}")
+        if len(items) > 20:
+            lines.append(f"  _({len(items) - 20} more occurrences not shown)_")
+        lines.append("")
+    lines += [
+        "## Next steps",
+        "",
+        "For each ticked item, run `/harness-report` to tag it as a `FRICTION:` payload "
+        "in `wing=harness-friction`. It will appear in the next regular curator sweep.",
+    ]
+    return "\n".join(lines)
+
+
 # --- Main -----------------------------------------------------------------
 
 
 def main() -> int:
+    if DEEP_MODE:
+        if STDIN_FILE:
+            try:
+                drawers = read_from_stdin_file()
+            except (OSError, ValueError) as e:
+                print(f"Error: failed to read stdin JSON: {e}", file=sys.stderr)
+                return 2
+        else:
+            drawers = read_transcripts_window(DEEP_WINDOW)
+        candidates = []
+        for drawer in drawers:
+            content = drawer.get("content", "")
+            matched = [
+                label
+                for label, pat in _DEEP_HEURISTICS.items()
+                if re.search(pat, content, re.IGNORECASE)
+            ]
+            if matched:
+                candidates.append({**drawer, "matched_patterns": matched})
+        review = compose_deep_review(candidates, len(drawers), DEEP_WINDOW)
+        _REAL_STDOUT.write(review)
+        _REAL_STDOUT.write("\n")
+        _REAL_STDOUT.flush()
+        return 0
+
     if STDIN_FILE:
         try:
             drawers = read_from_stdin_file()

--- a/.gemini/skills/harness-curator/scripts/curate.sh
+++ b/.gemini/skills/harness-curator/scripts/curate.sh
@@ -15,6 +15,7 @@
 #                          [--from-stdin]
 #                          [--target-repo <url>]
 #                          [--threshold <n>]
+#                          [--deep] [--deep-window <n>]
 #
 # Options:
 #   --dry-run        Output JSON of clusters that would become issues (default).
@@ -25,6 +26,11 @@
 #                    provenance routing). For tests / single-fork curation.
 #   --threshold      Minimum cluster size to propose an issue (default: 2).
 #                    Severity-`high` frictions bypass this and always cluster.
+#   --deep           Deep sweep mode: scan wing=transcripts with heuristic
+#                    pre-filtering and emit a Markdown review document
+#                    instead of clusters/issues. Incompatible with --apply.
+#   --deep-window    Maximum number of transcript drawers to scan in --deep
+#                    mode (default: 500).
 #
 # Environment:
 #   MEMPALACE_PYTHON Python binary with `mempalace` installed (auto-detected
@@ -42,6 +48,8 @@ DRY_RUN=true
 FROM_STDIN=false
 TARGET_REPO=""
 THRESHOLD=2
+DEEP_MODE=false
+DEEP_WINDOW=500
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -50,8 +58,10 @@ while [[ $# -gt 0 ]]; do
     --from-stdin)     FROM_STDIN=true; shift ;;
     --target-repo)    TARGET_REPO="$2"; shift 2 ;;
     --threshold)      THRESHOLD="$2"; shift 2 ;;
+    --deep)           DEEP_MODE=true; shift ;;
+    --deep-window)    DEEP_WINDOW="$2"; shift 2 ;;
     --help|-h)
-      sed -n '2,30p' "$0"
+      sed -n '2,33p' "$0"
       exit 0
       ;;
     *)
@@ -64,6 +74,11 @@ done
 
 if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]] || [ "$THRESHOLD" -lt 1 ]; then
   echo "Error: --threshold must be a positive integer" >&2
+  exit 1
+fi
+
+if [ "$DEEP_MODE" = true ] && [ "$DRY_RUN" = false ]; then
+  echo "Error: --deep is incompatible with --apply (--deep produces a review document only)." >&2
   exit 1
 fi
 
@@ -115,9 +130,16 @@ CURATE_OUT=$(env \
   THRESHOLD="$THRESHOLD" \
   TARGET_REPO_OVERRIDE="$TARGET_REPO" \
   FROM_STDIN_FILE="$STDIN_FILE" \
+  DEEP_MODE="$DEEP_MODE" \
+  DEEP_WINDOW="$DEEP_WINDOW" \
   "$MEMPALACE_PYTHON" "$(dirname "$0")/curate.py")
 
 # --- Output / apply ---
+if [ "$DEEP_MODE" = true ]; then
+  printf '%s\n' "$CURATE_OUT"
+  exit 0
+fi
+
 if [ "$DRY_RUN" = true ]; then
   printf '%s\n' "$CURATE_OUT"
   exit 0

--- a/community-config/skills/harness-curator/SKILL.md
+++ b/community-config/skills/harness-curator/SKILL.md
@@ -4,7 +4,9 @@ description: "Harness feedback-loop curator. Activate on demand to read
   friction tags from the global harness-friction wing, cluster them, and
   open one descriptive issue per cluster on the canonical/feedback repos
   declared in components' provenance blocks. The fix MR lands later
-  (human-authored or via the auto-fix mode tracked in #42)."
+  (human-authored or via the auto-fix mode tracked in #42). Also supports
+  a `--deep` mode that sweeps `wing=transcripts` with heuristic
+  pre-filtering and emits a Markdown review document for triage."
 type: skill
 license: Apache-2.0
 compatibility: Requires bash, jq, the gh CLI (used by setup-labels.sh and --apply), and the mempalace Python package (pipx install 'mempalace>=3.3.3,<3.4').
@@ -12,7 +14,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.2.0"
+    version: "1.3.0"
 claude:
   allowed-tools:
     - Read
@@ -163,9 +165,35 @@ If `--apply` fails on a missing label, the script surfaces it as a
 `failures:` entry in the run summary. The maintainer creates the
 label and retries.
 
-`--deep` mode (sweep `wing="transcripts"` for unflagged friction
-patterns) is **out of V0 scope** — tracked in issue #43. Auto mode is
-tracked in issue #42.
+### --deep mode
+
+Run a heuristic sweep of `wing="transcripts"` instead of the regular
+`wing="harness-friction"` curation. Useful for catching frictions that
+slipped through the recognition signals and were never tagged.
+
+```bash
+bash scripts/curate.sh --deep
+# Tune the scan window (default: 500 most-recent transcript drawers):
+bash scripts/curate.sh --deep --deep-window 1000
+```
+
+Behavior:
+
+- Reads up to `--deep-window` drawers from `wing="transcripts"` (most
+  recent first).
+- Pre-filters each drawer against a fixed set of heuristic regex
+  patterns (`error`, `failed`, `retry`, `not working`, `unexpected`,
+  `broken`, `didn't work`, `try again`).
+- Emits a **Markdown review document** on stdout — not JSON, not
+  issues. Each candidate appears as a checkbox item grouped by pattern,
+  with a one-line excerpt for triage.
+- Incompatible with `--apply`: the script exits with an error if both
+  are passed. Deep mode is a discovery aid, not an issue-opening path.
+  To promote a candidate, the human (or agent) runs `/harness-report`
+  for it, which lands a `FRICTION:` payload in `wing="harness-friction"`
+  for the next regular sweep.
+
+Auto mode is tracked in issue #42.
 
 ### 5. Run summary
 

--- a/community-config/skills/harness-curator/scripts/curate.py
+++ b/community-config/skills/harness-curator/scripts/curate.py
@@ -66,6 +66,20 @@ WING = os.environ.get("FRICTION_WING", "harness-friction")
 THRESHOLD = int(os.environ.get("THRESHOLD", "2"))
 TARGET_OVERRIDE = os.environ.get("TARGET_REPO_OVERRIDE", "").strip()
 STDIN_FILE = os.environ.get("FROM_STDIN_FILE", "").strip()
+DEEP_MODE = os.environ.get("DEEP_MODE", "false").lower() == "true"
+DEEP_WINDOW = int(os.environ.get("DEEP_WINDOW", "500"))
+
+# Heuristic keyword patterns for --deep pre-filter (label → regex)
+_DEEP_HEURISTICS: Dict[str, str] = {
+    "FAILED":        r"\bfailed\b",
+    "error":         r"\berror\b",
+    "retry":         r"\bretry\b",
+    "didn't work":   r"didn.t work",
+    "not working":   r"not working",
+    "unexpected":    r"\bunexpected\b",
+    "broken":        r"\bbroken\b",
+    "try again":     r"try again",
+}
 
 # Keep the page size aligned with prune-transcripts.sh: 100 is the sweet spot
 # between MCP roundtrips and per-call payload size.
@@ -413,10 +427,131 @@ def cluster_labels(cluster: List[Dict[str, Any]]) -> List[str]:
     ]
 
 
+# --- Deep mode ------------------------------------------------------------
+
+
+def read_transcripts_window(window: int) -> List[Dict[str, Any]]:
+    """Read at most `window` drawers from wing=transcripts (most recent first)."""
+    try:
+        from mempalace.mcp_server import tool_get_drawer, tool_list_drawers
+    except ImportError as e:
+        print(f"Error: failed to import mempalace ({e}).", file=sys.stderr)
+        sys.exit(2)
+    drawers: List[Dict[str, Any]] = []
+    offset = 0
+    while len(drawers) < window:
+        page_size = min(PAGE_SIZE, window - len(drawers))
+        page = tool_list_drawers(wing="transcripts", limit=page_size, offset=offset)
+        batch = page.get("drawers", [])
+        if not batch:
+            break
+        for stub in batch:
+            did = stub.get("drawer_id")
+            if not did:
+                continue
+            full = tool_get_drawer(drawer_id=did)
+            drawers.append({
+                "drawer_id": did,
+                "room": full.get("room", "") or stub.get("room", ""),
+                "content": full.get("content", ""),
+                "filed_at": (full.get("metadata") or {}).get("filed_at", ""),
+            })
+        if len(batch) < page_size:
+            break
+        offset += page_size
+    return drawers
+
+
+def _deep_excerpt(content: str, pattern: str) -> str:
+    """Return the first line containing `pattern` (capped at 120 chars)."""
+    for line in content.splitlines():
+        if re.search(pattern, line, re.IGNORECASE):
+            excerpt = line.strip()
+            return excerpt[:120] + "…" if len(excerpt) > 120 else excerpt
+    return ""
+
+
+def compose_deep_review(
+    candidates: List[Dict[str, Any]],
+    total_scanned: int,
+    window: int,
+) -> str:
+    """Compose a Markdown review document from heuristic candidates."""
+    import datetime
+    today = datetime.date.today().isoformat()
+    by_pattern: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for c in candidates:
+        for pat_label in c["matched_patterns"]:
+            by_pattern[pat_label].append(c)
+
+    lines: List[str] = [
+        f"# Harness Deep Sweep — {today}",
+        "",
+        f"Scanned **{total_scanned}** drawers from `wing=transcripts` (window: {window}).",
+        f"Pre-filtered to **{len(candidates)}** candidate drawers matching heuristic patterns.",
+        "",
+        "> Tick the items you want to promote to real friction tags, then run `/harness-report`",
+        "> for each one to create a `FRICTION:` payload in `wing=harness-friction`.",
+        "",
+    ]
+    for pat_label, items in sorted(by_pattern.items(), key=lambda kv: -len(kv[1])):
+        pattern_re = _DEEP_HEURISTICS[pat_label]
+        lines.append(
+            f"## Pattern: `{pat_label}` "
+            f"({len(items)} occurrence{'s' if len(items) != 1 else ''})"
+        )
+        lines.append("")
+        shown = items[:20]
+        for item in shown:
+            date = item["filed_at"].split("T")[0] if item.get("filed_at") else "unknown"
+            lines.append(
+                f"- [ ] Drawer `{item['drawer_id']}` "
+                f"(room: `{item['room'] or '?'}`, date: {date})"
+            )
+            excerpt = _deep_excerpt(item["content"], pattern_re)
+            if excerpt:
+                lines.append(f"  > {excerpt}")
+        if len(items) > 20:
+            lines.append(f"  _({len(items) - 20} more occurrences not shown)_")
+        lines.append("")
+    lines += [
+        "## Next steps",
+        "",
+        "For each ticked item, run `/harness-report` to tag it as a `FRICTION:` payload "
+        "in `wing=harness-friction`. It will appear in the next regular curator sweep.",
+    ]
+    return "\n".join(lines)
+
+
 # --- Main -----------------------------------------------------------------
 
 
 def main() -> int:
+    if DEEP_MODE:
+        if STDIN_FILE:
+            try:
+                drawers = read_from_stdin_file()
+            except (OSError, ValueError) as e:
+                print(f"Error: failed to read stdin JSON: {e}", file=sys.stderr)
+                return 2
+        else:
+            drawers = read_transcripts_window(DEEP_WINDOW)
+        candidates = []
+        for drawer in drawers:
+            content = drawer.get("content", "")
+            matched = [
+                label
+                for label, pat in _DEEP_HEURISTICS.items()
+                if re.search(pat, content, re.IGNORECASE)
+            ]
+            if matched:
+                candidates.append({**drawer, "matched_patterns": matched})
+        review = compose_deep_review(candidates, len(drawers), DEEP_WINDOW)
+        _REAL_STDOUT.write(review)
+        _REAL_STDOUT.write("\n")
+        _REAL_STDOUT.flush()
+        return 0
+
     if STDIN_FILE:
         try:
             drawers = read_from_stdin_file()

--- a/community-config/skills/harness-curator/scripts/curate.sh
+++ b/community-config/skills/harness-curator/scripts/curate.sh
@@ -15,6 +15,7 @@
 #                          [--from-stdin]
 #                          [--target-repo <url>]
 #                          [--threshold <n>]
+#                          [--deep] [--deep-window <n>]
 #
 # Options:
 #   --dry-run        Output JSON of clusters that would become issues (default).
@@ -25,6 +26,11 @@
 #                    provenance routing). For tests / single-fork curation.
 #   --threshold      Minimum cluster size to propose an issue (default: 2).
 #                    Severity-`high` frictions bypass this and always cluster.
+#   --deep           Deep sweep mode: scan wing=transcripts with heuristic
+#                    pre-filtering and emit a Markdown review document
+#                    instead of clusters/issues. Incompatible with --apply.
+#   --deep-window    Maximum number of transcript drawers to scan in --deep
+#                    mode (default: 500).
 #
 # Environment:
 #   MEMPALACE_PYTHON Python binary with `mempalace` installed (auto-detected
@@ -42,6 +48,8 @@ DRY_RUN=true
 FROM_STDIN=false
 TARGET_REPO=""
 THRESHOLD=2
+DEEP_MODE=false
+DEEP_WINDOW=500
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -50,8 +58,10 @@ while [[ $# -gt 0 ]]; do
     --from-stdin)     FROM_STDIN=true; shift ;;
     --target-repo)    TARGET_REPO="$2"; shift 2 ;;
     --threshold)      THRESHOLD="$2"; shift 2 ;;
+    --deep)           DEEP_MODE=true; shift ;;
+    --deep-window)    DEEP_WINDOW="$2"; shift 2 ;;
     --help|-h)
-      sed -n '2,30p' "$0"
+      sed -n '2,33p' "$0"
       exit 0
       ;;
     *)
@@ -64,6 +74,11 @@ done
 
 if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]] || [ "$THRESHOLD" -lt 1 ]; then
   echo "Error: --threshold must be a positive integer" >&2
+  exit 1
+fi
+
+if [ "$DEEP_MODE" = true ] && [ "$DRY_RUN" = false ]; then
+  echo "Error: --deep is incompatible with --apply (--deep produces a review document only)." >&2
   exit 1
 fi
 
@@ -115,9 +130,16 @@ CURATE_OUT=$(env \
   THRESHOLD="$THRESHOLD" \
   TARGET_REPO_OVERRIDE="$TARGET_REPO" \
   FROM_STDIN_FILE="$STDIN_FILE" \
+  DEEP_MODE="$DEEP_MODE" \
+  DEEP_WINDOW="$DEEP_WINDOW" \
   "$MEMPALACE_PYTHON" "$(dirname "$0")/curate.py")
 
 # --- Output / apply ---
+if [ "$DEEP_MODE" = true ]; then
+  printf '%s\n' "$CURATE_OUT"
+  exit 0
+fi
+
 if [ "$DRY_RUN" = true ]; then
   printf '%s\n' "$CURATE_OUT"
   exit 0

--- a/community-config/skills/harness-curator/tests/fixtures/transcripts.json
+++ b/community-config/skills/harness-curator/tests/fixtures/transcripts.json
@@ -1,0 +1,26 @@
+[
+  {
+    "drawer_id": "t-fixture-001",
+    "room": "prompt",
+    "content": "Error: tool call failed with status 500\nThe agent retried but the error persisted.",
+    "filed_at": "2026-05-13T10:00:00"
+  },
+  {
+    "drawer_id": "t-fixture-002",
+    "room": "context",
+    "content": "retry attempt 3 of 5 — still not working, giving up.",
+    "filed_at": "2026-05-13T11:00:00"
+  },
+  {
+    "drawer_id": "t-fixture-003",
+    "room": "prompt",
+    "content": "The task completed successfully. No issues encountered.",
+    "filed_at": "2026-05-13T12:00:00"
+  },
+  {
+    "drawer_id": "t-fixture-004",
+    "room": "tools",
+    "content": "Unexpected response from API: missing required field 'id'.",
+    "filed_at": "2026-05-13T13:00:00"
+  }
+]


### PR DESCRIPTION
Adds a `--deep` mode to the Harness Curator that sweeps the high-volume `wing=transcripts` archive with heuristic pre-filtering and emits a Markdown review document for human triage. The default curator path (friction-tag clustering) is unchanged; deep mode is opt-in and incompatible with `--apply` because it never opens issues on its own.

Closes #43

## How to read this PR?

1. `community-config/skills/harness-curator/SKILL.md` — the contract: read the new `--deep` section first to understand the intent and the `--apply` incompatibility.
2. `community-config/skills/harness-curator/scripts/curate.sh` — CLI surface: new `--deep` / `--deep-window` flags, the incompatibility guard, and dispatch into the Python entrypoint.
3. `community-config/skills/harness-curator/scripts/curate.py` — core logic: `read_transcripts_window` (windowed read, default 500 drawers) + `compose_deep_review` (heuristic pre-filter on patterns like `FAILED`, `error`, `retry`, `not working`, then Markdown report). The constants `DEEP_MODE` / `DEEP_WINDOW` carry config.
4. `community-config/skills/harness-curator/tests/fixtures/transcripts.json` — smoke-test fixture: 4 drawers (3 matching heuristics, 1 clean) for local verification without a live MemPalace wing.
5. `.claude/` and `.gemini/` — regenerated mirrors via `bash scripts/build-components.sh`; no hand edits.

Design notes:
- **Window default 500** — bounds the sweep cost and keeps BM25 noise from drowning signal; overridable via `--deep-window`.
- **Markdown review document, not issues** — deep mode is exploratory; the operator decides what becomes an issue. This is why `--deep --apply` is a hard error rather than a warning.
- **Heuristic set** — `FAILED`, `error`, `retry`, `not working`, `unexpected`, `broken`, `try again`, `didn't work` (case-insensitive). Tuned for the friction signals already observed in transcripts; extending the set is a one-liner.

## How to test this PR?

```bash
# 1. Help text exposes both flags
bash community-config/skills/harness-curator/scripts/curate.sh --help

# 2. Incompatibility guard
bash community-config/skills/harness-curator/scripts/curate.sh --deep --apply
# → exits 1 with: Error: --deep is incompatible with --apply (--deep produces a review document only).

# 3. Deep sweep on the bundled fixture (4 drawers, 3 matching, 1 clean)
bash community-config/skills/harness-curator/scripts/curate.sh --deep --from-stdin \
  < community-config/skills/harness-curator/tests/fixtures/transcripts.json
# → Markdown report headed "# Harness Deep Sweep — ", lists t-fixture-001/002/004 with
#   matched patterns; clean t-fixture-003 excluded.

# 4. Mirrors are drift-free
bash scripts/build-components.sh && git diff --exit-code .claude .gemini

# 5. Existing regression suite
bash community-config/skills/harness-curator/scripts/test.sh
```

## Detailed description (for agents)

**Files modified:**
- `community-config/skills/harness-curator/scripts/curate.sh` — added `--deep` and `--deep-window` argument parsing; added incompatibility guard rejecting `--deep --apply` with exit code 1; threaded the new flags through to the Python entrypoint via env vars `DEEP_MODE` / `DEEP_WINDOW`.
- `community-config/skills/harness-curator/scripts/curate.py` — added module-level constants `DEEP_MODE` and `DEEP_WINDOW` (default 500); added `_DEEP_HEURISTICS` dict (8 patterns); added `read_transcripts_window(n)` to bound the read against the `transcripts` wing; added `_deep_excerpt` helper (120-char cap); added `compose_deep_review` performing case-insensitive heuristic matching and emitting a Markdown checklist with one section per matched pattern. Deep path is isolated at the top of `main()` — no entanglement with existing clustering logic.
- `community-config/skills/harness-curator/SKILL.md` — bumped to `version: "1.3.0"`; documented `--deep` mode, the `--deep-window` knob, the Markdown review output, and the explicit incompatibility with `--apply`.
- `community-config/skills/harness-curator/tests/fixtures/transcripts.json` — new fixture: 4 drawer stubs (t-fixture-001 `Error + FAILED`, t-fixture-002 `retry + not working`, t-fixture-003 clean, t-fixture-004 `unexpected`) for smoke-testing the deep-mode pre-filter locally without a live MemPalace wing.
- `.claude/` and `.gemini/` — regenerated bundles (no hand edits); verified drift-free post-rebuild.

**Verification (per tester, commit `fab9a9c`):**
- `--help` lists `--deep` and `--deep-window` (default 500).
- Guard: `curate.sh --deep --apply` exits 1 with the documented error.
- Fixture sweep (4 drawers): pre-filtered to 3 matches; clean drawer excluded.
- Bundles drift-free after `bash scripts/build-components.sh`.
- Existing `scripts/test.sh` regression suite passes.