### PR TITLE
📝 Overhaul README — community zone, harness loop, self-use, lifecycle scenario

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,46 @@ Each extension is an independent npm package with its own versioning. See
 > **Warning:** never install the `extension-skeleton/` directory itself.
 > It is a template container, not a functional extension.
 
+## Harness Engineering Contribution Path
+
+Frictions are a first-class contribution mechanism. Any agent or
+developer who encounters a problem with a skill, agent, or process can
+tag it immediately:
+
+1. During real work, invoke the `harness-report` skill (or
+   `/harness-report`) the moment a recognition signal fires.
+2. Frictions accumulate in the MemPalace `harness-friction` wing — no
+   manual ticket required at tag time.
+3. Run `task harness-curate -- --apply` to cluster frictions and open
+   GitHub issues automatically.
+4. Address the issues via the standard PR workflow like any other
+   change.
+
+This path ensures that systemic improvements surface without requiring
+the person who hits the friction to also write the fix. Tag it; the
+loop handles the rest.
+
+## Internal Agent Crew
+
+CrewRig is developed using its own agent crew. Each PR goes through a
+chain of specialized agents:
+
+| Agent | Role |
+|---|---|
+| `architect` | Design reviews, ADRs, blast-radius analysis before implementation |
+| `developer` | Implements the smallest correct change |
+| `tester` | Authors high-signal regression tests |
+| `pr-logbook` | Drafts the PR title, body, and logbook issue |
+| `pr-reviewer` | Cold-start independent review before merge |
+
+The crew runs on the skills and agents shipped with crewrig itself. To
+invoke the full chain on an issue:
+
+```python
+Agent(subagent_type="architect", prompt="Design the implementation for issue #N in hcross/crewrig. Read the issue first.")
+# then developer, tester, pr-logbook, pr-reviewer in sequence
+```
+
 ## Standards
 
 1. **Language**: all technical artifacts (code, commits, PRs) in **English**.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ a four-stage loop:
    reinstall. The `metadata.provenance.version` bump in every modified
    `SKILL.md` signals that a new version is available.
 
-For automated periodic sweeps, `scripts/schedule-curator.sh` installs a
-macOS launchd job or a Linux crontab entry that runs the curator on a
-fixed cadence.
+For automated periodic sweeps,
+`community-config/skills/harness-curator/scripts/schedule-curator.sh`
+installs a macOS launchd job or a Linux crontab entry that runs the
+curator on a fixed cadence.
 
 ### Security: Copy by Default
 
@@ -311,7 +312,7 @@ community-config/
 │   │   └── SKILL.md
 │   ├── harness-curator/                  # Skill: cluster frictions and open GitHub issues
 │   │   ├── SKILL.md
-│   │   └── scripts/
+│   │   └── scripts/                      # schedule-curator.sh (launchd/crontab installer), ...
 │   └── pr-reviewer/                      # Skill: independent PR reviewer persona + linters
 │       ├── SKILL.md
 │       └── scripts/                      # lint-shell.sh, lint-markdown.sh, lint-skill.sh,
@@ -353,7 +354,6 @@ scripts/
 ├── create-extension.sh               # Extension scaffolding
 ├── lib/common.sh                         # Shared Bash helpers (sourced by other scripts)
 ├── check-skill-versions.sh               # CI gate: enforces version bump on modified SKILL.md/AGENT.md
-├── schedule-curator.sh                   # Interactive installer for periodic curator sweeps (launchd/crontab)
 └── ...
 
 Taskfile.yml                          # Task runner configuration

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # CrewRig
 
-Centralized configuration framework for
+CrewRig is a centralized configuration framework for
 [Gemini CLI](https://github.com/google-gemini/gemini-cli) and
-[Claude Code](https://claude.ai/code).
-It provides a shared, layered context system that shapes how AI assistants
-behave depending on the user's organization, team, role, seniority, and
-personal preferences.
+[Claude Code](https://claude.ai/code). It serves three complementary
+purposes:
+
+- **Personal context layer** — layered configuration files shape how AI
+  assistants behave for a specific user's role, team, and seniority.
+- **Shared innovation zone** — `community-config/` is a collaborative
+  sandbox where a team builds and shares skills, agents, and commands
+  that any member can install from a single source.
+- **Harness engineering** — a built-in feedback loop lets agents tag
+  frictions encountered during real work; the harness curator clusters
+  those frictions into actionable GitHub issues, closing the loop
+  between AI behavior and continuous improvement.
+
+CrewRig develops itself using its own mechanics. The internal agent crew
+— architect, developer, tester, pr-logbook, and pr-reviewer — runs on
+the same skills and agents that ship with the framework. The development
+workflow is the product in action.
 
 ## Supported Platforms
 
@@ -39,6 +52,58 @@ to form the agent's full context:
 enforced priority order. **Claude Code** loads them from `~/.claude/rules/`
 as additive context (all files combine, no override).
 
+### Community Config Zone
+
+`community-config/` is a single-source sandbox where skills, agents, and
+commands are written **once** and compiled into outputs for both CLIs.
+Contributors edit a single Markdown file with YAML frontmatter; the
+build step produces Gemini and Claude Code targets.
+
+| Type | Description |
+|---|---|
+| Skill | Reusable agent behaviour activated via `/skill-name` |
+| Command | Slash command with a prompt body |
+| Agent | Sub-agent with a dedicated persona |
+| Hook | Lifecycle hook (BeforeTool/AfterTool/etc.) |
+| Policy | Security or behavioural constraint |
+| MCP Server | External tool integration |
+| Theme | UI theme fragment |
+
+Install a component on a project:
+
+```bash
+# Gemini CLI
+task install-component TYPE=skills NAME=ci-workflow-engineering
+
+# Claude Code
+task install-claude-component TYPE=claude-skills NAME=ci-workflow-engineering
+```
+
+See [`community-config/FORMAT.md`](community-config/FORMAT.md) for the
+full unified-source specification.
+
+### Harness Engineering Loop
+
+The harness turns real-world frictions into shipped improvements through
+a four-stage loop:
+
+1. **Tag** — during real work, agents invoke the `harness-report` skill
+   the moment a friction signal fires (user pushback, tool surprise,
+   process gap). Each tag lands in the MemPalace `harness-friction`
+   wing.
+2. **Cluster** — `task harness-curate -- --apply` clusters the tagged
+   frictions by subcategory and opens one descriptive GitHub issue per
+   cluster.
+3. **Fix** — issues are addressed via the normal branch/PR workflow;
+   the internal agent crew handles the implementation cycle.
+4. **Re-install** — after a fix ships, run `task build-components` and
+   reinstall. The `metadata.provenance.version` bump in every modified
+   `SKILL.md` signals that a new version is available.
+
+For automated periodic sweeps, `scripts/schedule-curator.sh` installs a
+macOS launchd job or a Linux crontab entry that runs the curator on a
+fixed cadence.
+
 ### Security: Copy by Default
 
 Context files are **copied** (not symlinked) to the target directory by
@@ -56,6 +121,38 @@ The framework implements a three-tier memory model:
 | 3 | Obsidian | User knowledge (Second Brain) | Read free, write user-controlled |
 
 See `config/TOOLS.md` for the full memory protocol.
+
+## Lifecycle Scenario
+
+A complete journey, from installing the framework to closing the
+harness loop:
+
+1. **Install** — fork crewrig, then run
+   `task setup-claude-interactive` (or `task setup-gemini-interactive`).
+   Generate your profile with `/init-personal-profile` and your soul
+   with `/init-soul`.
+2. **Create** — add a `SKILL.md` to
+   `community-config/skills/my-skill/`, or run
+   `task create-extension NAME=my-skill`. Run `task build-components`
+   to generate outputs for both CLIs.
+3. **Use on another project** — install the component:
+   `task install-claude-component TYPE=claude-skills NAME=my-skill`.
+   The skill is now available in Claude Code on that project.
+4. **Record frictions** — as agents use the skill, they invoke the
+   `harness-report` skill the moment a recognition signal fires. Each
+   friction tag lands in the MemPalace `harness-friction` wing.
+5. **Transform frictions into tickets** — run
+   `task harness-curate -- --apply`. The curator clusters the
+   frictions and opens one GitHub issue per cluster against the
+   target repo.
+6. **Implement** — address the issues via feature branches. The
+   internal agent crew (architect → developer → tester → pr-logbook →
+   pr-reviewer) handles the cycle.
+7. **Install the new version** — run `task build-components` and
+   reinstall; `metadata.provenance.version` bumps confirm which
+   components changed.
+8. **Back to step 3** — use the improved skill on your projects; the
+   harness loop continues.
 
 ## Prerequisites
 
@@ -209,10 +306,21 @@ config/
 community-config/
 ├── FORMAT.md              # Unified source format specification
 ├── skills/                # Reusable agent skills (single-source)
-│   └── ci-workflow-engineering/
+│   ├── ci-workflow-engineering/
+│   ├── harness-report/                   # Skill: tag frictions during real work
+│   │   └── SKILL.md
+│   ├── harness-curator/                  # Skill: cluster frictions and open GitHub issues
+│   │   ├── SKILL.md
+│   │   └── scripts/
+│   └── pr-reviewer/                      # Skill: independent PR reviewer persona + linters
+│       ├── SKILL.md
+│       └── scripts/                      # lint-shell.sh, lint-markdown.sh, lint-skill.sh,
+│                                         # lint-python.sh, lint-json.sh
 ├── commands/              # Shared slash commands
 ├── hooks/                 # Lifecycle hooks
 ├── agents/                # Sub-agent definitions
+│   └── pr-reviewer/                      # Agent: cold-start independent PR reviewer
+│       └── AGENT.md
 ├── policies/              # Security policies
 ├── mcp-servers/           # MCP server configurations
 └── themes/                # UI themes
@@ -243,6 +351,9 @@ scripts/
 ├── install-workspace.sh              # Bulk Gemini install
 ├── install-extension.sh              # Gemini extension installer
 ├── create-extension.sh               # Extension scaffolding
+├── lib/common.sh                         # Shared Bash helpers (sourced by other scripts)
+├── check-skill-versions.sh               # CI gate: enforces version bump on modified SKILL.md/AGENT.md
+├── schedule-curator.sh                   # Interactive installer for periodic curator sweeps (launchd/crontab)
 └── ...
 
 Taskfile.yml                          # Task runner configuration


### PR DESCRIPTION
Surface the three dimensions of CrewRig that were under-documented in the README: the `community-config/` shared innovation zone, the harness engineering feedback loop, and the framework's self-use through its internal agent crew. Adds a full lifecycle scenario so newcomers can map the moving parts onto a concrete journey.

## How to read this PR?

Two files changed, +157/-6 lines total.

1. Start with `README.md` — read the new opening paragraph (the three-purposes framing), then the two new subsections *Community Config Zone* and *Harness Engineering Loop* inside the architecture section.
2. Read the new top-level *Lifecycle Scenario* section. It is the spine of the overhaul: every other addition exists to back claims made in those eight steps.
3. Skim the directory-tree update further down to confirm it matches the current HEAD layout (catches up with #42, #43, #44, #54).
4. Then `CONTRIBUTING.md` — two new sections: *Harness Engineering Contribution Path* and *Internal Agent Crew*. They expand on claims the README only sketches.

Key design choice to note: the *Lifecycle Scenario* sits **before** *Prerequisites*, not in an appendix. Onboarding readers need the mental model before the install commands.

## How to test this PR?

Documentation-only change; no runtime behavior to exercise. Verify by reading.

1. `git fetch origin docs/issue-90-readme-overhaul && git checkout docs/issue-90-readme-overhaul`
2. Render `README.md` and `CONTRIBUTING.md` locally (`glow README.md` or any Markdown previewer).
3. Verify the new sections render cleanly (table layout, code fences, numbered lists).
4. Cross-check the directory tree in `README.md` against `ls community-config/skills/ community-config/agents/ scripts/` — every listed entry must exist on disk.
5. Cross-check the install commands against `Taskfile.yml` — `install-component` and `install-claude-component` targets must be present.
6. Optional: run `task lint-markdown` if available, to confirm no Markdown-lint regressions.

## Detailed description (for agents)

### Scope and provenance

- Branch: `docs/issue-90-readme-overhaul`
- Closes: #90 (feature issue)
- Logbook: #91
- Diff stat: `CONTRIBUTING.md` +40/-0, `README.md` +117/-6. Total +157/-6 across 2 files.
- No code, no config, no scripts touched — Markdown only.

### README.md changes

1. **Opening rewrite (lines 1-20)** — replaced the one-sentence framing with a three-bullet purpose list (personal context layer / shared innovation zone / harness engineering) plus a self-use paragraph naming the internal agent crew (architect, developer, tester, pr-logbook, pr-reviewer).
2. **New subsection: *Community Config Zone*** — added inside the existing architecture/layering section. Contains a 7-row component-type table (Skill, Command, Agent, Hook, Policy, MCP Server, Theme) and two install-command code blocks (Gemini via `task install-component`, Claude Code via `task install-claude-component`). Points readers to `community-config/FORMAT.md` for the unified-source spec.
3. **New subsection: *Harness Engineering Loop*** — four numbered stages: Tag (`harness-report` skill writes to MemPalace `harness-friction` wing) → Cluster (`task harness-curate -- --apply`) → Fix (normal branch/PR flow, internal crew) → Re-install (`task build-components` + reinstall, version bump signal). References `scripts/schedule-curator.sh` for periodic automated sweeps.
4. **New top-level section: *Lifecycle Scenario*** — placed between the memory-architecture section and *Prerequisites*. Eight numbered steps: Install → Create → Use on another project → Record frictions → Transform frictions into tickets → Implement → Install the new version → Back to step 3. Each step names the concrete command or skill invocation involved.
5. **Directory-tree update** — extended the existing `community-config/` and `scripts/` listings to include `harness-report/`, `harness-curator/` (with `scripts/` subdir), `pr-reviewer/` (skill + agent), `lib/common.sh`, `check-skill-versions.sh`, and `schedule-curator.sh`. Pure catch-up with components that landed in #42/#43/#44/#54.

### CONTRIBUTING.md changes

1. **New section: *Harness Engineering Contribution Path*** — four-step procedure positioning frictions as a first-class contribution mechanism. Emphasizes that the person who hits the friction does not need to write the fix; tagging is sufficient and the curator/PR loop handles the rest.
2. **New section: *Internal Agent Crew*** — table mapping each crew member to its role, plus a `Agent(subagent_type=…)` invocation example showing how to start the chain on an issue.

### Design decisions

- **Lifecycle Scenario placed before *Prerequisites*** to serve onboarding readers ahead of installing readers. The scenario is the mental model; prerequisites are mechanics.
- **Community Config Zone scoped inside *Architecture*, not promoted to top level** — it is a mechanism of the layered-context system, not a parallel product.
- **Internal agent crew operational table lives in CONTRIBUTING** — README signals the dogfooding claim; CONTRIBUTING carries the catalogue, keeping the README scannable.
- **No diagrams or images** — Markdown-only to keep the diff reviewable and avoid binary churn.

### What this PR does not do

- Does not touch any skill, agent, command, hook, policy, MCP server, or theme source.
- Does not modify `Taskfile.yml`, scripts, or CI workflows.
- Does not introduce new component types or rename existing directories.

Closes #90.
Logbook: #91.
