### PR TITLE
🐛 Enforce diff-scope check in developer Prove-it-locally step

### DIFF
--- a/.claude/skills/developer/SKILL.md
+++ b/.claude/skills/developer/SKILL.md
@@ -15,7 +15,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -62,6 +62,13 @@ genuine duplication emerges, the next change will surface it.
 
 Before reporting a task as done, run:
 
+- Review the full diff (`git diff HEAD`) against the declared task scope
+  before reporting done. Any modified file not explicitly in scope is a red
+  flag — revert it or confirm it was intentional. Pay special attention to
+  Unicode → ASCII regressions (e.g. `→` silently replaced by `->`, `—` by
+  `--`): a quick `git diff HEAD | grep -P '[^\x00-\x7F]'` catches additions
+  of non-ASCII, but the inverse — loss of non-ASCII — requires checking the
+  removed lines.
 - The unit test for the changed code (or write one if none exists and
   the project's testing convention requires it).
 - The narrowest type-check / lint that covers the change.

--- a/.gemini/skills/developer/SKILL.md
+++ b/.gemini/skills/developer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -54,6 +54,13 @@ genuine duplication emerges, the next change will surface it.
 
 Before reporting a task as done, run:
 
+- Review the full diff (`git diff HEAD`) against the declared task scope
+  before reporting done. Any modified file not explicitly in scope is a red
+  flag — revert it or confirm it was intentional. Pay special attention to
+  Unicode → ASCII regressions (e.g. `→` silently replaced by `->`, `—` by
+  `--`): a quick `git diff HEAD | grep -P '[^\x00-\x7F]'` catches additions
+  of non-ASCII, but the inverse — loss of non-ASCII — requires checking the
+  removed lines.
 - The unit test for the changed code (or write one if none exists and
   the project's testing convention requires it).
 - The narrowest type-check / lint that covers the change.

--- a/community-config/skills/developer/SKILL.md
+++ b/community-config/skills/developer/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.0"
+    version: "1.1.1"
 claude:
   allowed-tools:
     - Read
@@ -66,6 +66,13 @@ genuine duplication emerges, the next change will surface it.
 
 Before reporting a task as done, run:
 
+- Review the full diff (`git diff HEAD`) against the declared task scope
+  before reporting done. Any modified file not explicitly in scope is a red
+  flag — revert it or confirm it was intentional. Pay special attention to
+  Unicode → ASCII regressions (e.g. `→` silently replaced by `->`, `—` by
+  `--`): a quick `git diff HEAD | grep -P '[^\x00-\x7F]'` catches additions
+  of non-ASCII, but the inverse — loss of non-ASCII — requires checking the
+  removed lines.
 - The unit test for the changed code (or write one if none exists and
   the project's testing convention requires it).
 - The narrowest type-check / lint that covers the change.


### PR DESCRIPTION
Adds a diff-scope review step to the developer skill's *Prove it locally*
checklist so agents catch out-of-scope edits — notably silent Unicode →
ASCII regressions — before reporting a task done. Closes #93; logbook in
#97.

## How to read this PR?

One logical change mirrored across three files (canonical + two harness
mirrors). Read in this order:

1. `community-config/skills/developer/SKILL.md` — canonical source, see the
   provenance bump (`1.1.0` → `1.1.1`) and the new bullets at the top of
   the *Prove it locally* section.
2. `.claude/skills/developer/SKILL.md` and `.gemini/skills/developer/SKILL.md`
   — verify the mirrors are byte-identical to the canonical change.

The three diffs are intentionally identical; reviewing one is reviewing all
three.

## How to test this PR?

No code, no tests — documentation-only change to skill files. Verify:

1. `git diff origin/main..HEAD --stat` shows exactly three files changed
   (24 insertions, 3 deletions).
2. `git diff origin/main..HEAD -- '*/skills/developer/SKILL.md'` shows the
   same hunk in each of the three files (modulo path).
3. The new checklist bullets render correctly in Markdown previewers
   (escaped backticks around the `grep -P` recipe).

## Detailed description (for agents)

**Trigger.** Curator cluster `developer-out-of-scope-edit` (#93, 1
friction report, severity `med`, room `behavior`) flagged that the
developer skill allowed an agent to silently replace `→` with `->` in
`scripts/import-*-history.sh` echo banners while doing unrelated work.
The reporter's converging suggestion was to add a diff-scope review step
to the *Prove it locally* gate, with a grep sentinel for Unicode → ASCII
drift.

**Change.** A 7-line addition placed at the top of the *Prove it locally*
checklist in three mirrored SKILL.md files:

- `community-config/skills/developer/SKILL.md` (canonical)
- `.claude/skills/developer/SKILL.md` (Claude Code mirror)
- `.gemini/skills/developer/SKILL.md` (Gemini CLI mirror)

The new bullet instructs the agent to (1) run `git diff HEAD` and compare
modified files to the declared task scope; (2) treat any out-of-scope hunk
as a red flag — revert or confirm intentional; (3) watch for Unicode →
ASCII regressions (`→`→`->`, `—`→`--`); (4) use
`git diff HEAD | grep -P '[^\x00-\x7F]'` as a cheap sentinel for new
non-ASCII, with the caveat that the inverse (loss of non-ASCII) requires
inspecting removed lines manually.

**Provenance.** Version bumped `1.1.0` → `1.1.1` in all three files. Patch
semver: additive checklist item, no contract change, no new tool
requirement.

**Out of scope.** Promoting the grep sentinel to a pre-commit hook or
harness-level guard. The skill text covers both directions of the
regression (added and removed non-ASCII); automation is a future
iteration.

**Linked artefacts.** Closes #93. Logbook: #97.
