### PR TITLE
🐛 Require git fetch before branch creation in developer skill

### DIFF
--- a/.claude/skills/developer/SKILL.md
+++ b/.claude/skills/developer/SKILL.md
@@ -15,7 +15,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 
@@ -37,7 +37,22 @@ the change touches auth, secrets, crypto, or external input handling.
 
 ## Operating mode
 
-### 1. Read before writing
+### 1. Branch setup
+
+Before creating your branch, always synchronise with the remote to
+avoid basing work on a stale commit:
+
+```sh
+git fetch origin
+git checkout -b <branch-name> origin/main
+```
+
+Never use `git checkout -b <branch> main` (local ref) — it may be
+behind `origin/main` if the remote was updated since your last fetch,
+which causes the branch to miss recently merged PRs and forces a
+rebase round-trip.
+
+### 2. Read before writing
 
 Read the file you are about to modify. Read the function calling it.
 Read the tests around it. Two minutes of reading saves twenty minutes
@@ -46,7 +61,7 @@ of guessing.
 If the codebase is unfamiliar, run a focused grep for the symbol or
 pattern you intend to change before editing — never edit blind.
 
-### 2. Smallest correct change
+### 3. Smallest correct change
 
 Write the change that solves the stated problem. Resist:
 
@@ -58,7 +73,7 @@ Write the change that solves the stated problem. Resist:
 Three repeated lines is preferable to a premature abstraction. If a
 genuine duplication emerges, the next change will surface it.
 
-### 3. Prove it locally
+### 4. Prove it locally
 
 Before reporting a task as done, run:
 
@@ -91,7 +106,7 @@ Before reporting a task as done, run:
 If the project has no test or type-check infrastructure, say so
 explicitly in the report — do not claim verification you did not do.
 
-### 4. Parallelisable work
+### 5. Parallelisable work
 
 When a task decomposes into independent subtasks (e.g. apply the same
 fix to several files), prefer launching them concurrently rather than

--- a/.gemini/skills/developer/SKILL.md
+++ b/.gemini/skills/developer/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 
@@ -29,7 +29,22 @@ the change touches auth, secrets, crypto, or external input handling.
 
 ## Operating mode
 
-### 1. Read before writing
+### 1. Branch setup
+
+Before creating your branch, always synchronise with the remote to
+avoid basing work on a stale commit:
+
+```sh
+git fetch origin
+git checkout -b <branch-name> origin/main
+```
+
+Never use `git checkout -b <branch> main` (local ref) — it may be
+behind `origin/main` if the remote was updated since your last fetch,
+which causes the branch to miss recently merged PRs and forces a
+rebase round-trip.
+
+### 2. Read before writing
 
 Read the file you are about to modify. Read the function calling it.
 Read the tests around it. Two minutes of reading saves twenty minutes
@@ -38,7 +53,7 @@ of guessing.
 If the codebase is unfamiliar, run a focused grep for the symbol or
 pattern you intend to change before editing — never edit blind.
 
-### 2. Smallest correct change
+### 3. Smallest correct change
 
 Write the change that solves the stated problem. Resist:
 
@@ -50,7 +65,7 @@ Write the change that solves the stated problem. Resist:
 Three repeated lines is preferable to a premature abstraction. If a
 genuine duplication emerges, the next change will surface it.
 
-### 3. Prove it locally
+### 4. Prove it locally
 
 Before reporting a task as done, run:
 
@@ -83,7 +98,7 @@ Before reporting a task as done, run:
 If the project has no test or type-check infrastructure, say so
 explicitly in the report — do not claim verification you did not do.
 
-### 4. Parallelisable work
+### 5. Parallelisable work
 
 When a task decomposes into independent subtasks (e.g. apply the same
 fix to several files), prefer launching them concurrently rather than

--- a/community-config/skills/developer/SKILL.md
+++ b/community-config/skills/developer/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.1"
+    version: "1.1.2"
 claude:
   allowed-tools:
     - Read
@@ -41,7 +41,22 @@ the change touches auth, secrets, crypto, or external input handling.
 
 ## Operating mode
 
-### 1. Read before writing
+### 1. Branch setup
+
+Before creating your branch, always synchronise with the remote to
+avoid basing work on a stale commit:
+
+```sh
+git fetch origin
+git checkout -b <branch-name> origin/main
+```
+
+Never use `git checkout -b <branch> main` (local ref) — it may be
+behind `origin/main` if the remote was updated since your last fetch,
+which causes the branch to miss recently merged PRs and forces a
+rebase round-trip.
+
+### 2. Read before writing
 
 Read the file you are about to modify. Read the function calling it.
 Read the tests around it. Two minutes of reading saves twenty minutes
@@ -50,7 +65,7 @@ of guessing.
 If the codebase is unfamiliar, run a focused grep for the symbol or
 pattern you intend to change before editing — never edit blind.
 
-### 2. Smallest correct change
+### 3. Smallest correct change
 
 Write the change that solves the stated problem. Resist:
 
@@ -62,7 +77,7 @@ Write the change that solves the stated problem. Resist:
 Three repeated lines is preferable to a premature abstraction. If a
 genuine duplication emerges, the next change will surface it.
 
-### 3. Prove it locally
+### 4. Prove it locally
 
 Before reporting a task as done, run:
 
@@ -95,7 +110,7 @@ Before reporting a task as done, run:
 If the project has no test or type-check infrastructure, say so
 explicitly in the report — do not claim verification you did not do.
 
-### 4. Parallelisable work
+### 5. Parallelisable work
 
 When a task decomposes into independent subtasks (e.g. apply the same
 fix to several files), prefer launching them concurrently rather than


### PR DESCRIPTION
Adds an explicit `git fetch origin && git checkout -b <branch> origin/main` step at the start of the developer skill's operating mode, so branches are never based on a stale local `main`. Closes #94 and is tracked in logbook #99.

## How to read this PR?

Single logical change mirrored across three skill copies — read one, then verify the other two are identical:

1. `community-config/skills/developer/SKILL.md` — canonical copy. Read the new **step 1: Branch setup** section and the renumbering of steps 2 → 5.
2. `.claude/skills/developer/SKILL.md` and `.gemini/skills/developer/SKILL.md` — mirrors. Should differ from the canonical only at paths/comments that were already different before this PR.
3. Provenance `version` bumped `1.1.1` → `1.1.2` in all three.

No code paths change; this is a prompt edit to a skill the agent reads at activation.

## How to test this PR?

```sh
git fetch origin
git checkout -b test/issue-94-verify origin/fix/issue-94-developer-fetch-before-branch
git diff origin/main -- '*/skills/developer/SKILL.md'
```

Expected:

- 3 files changed, +60/-15.
- All three mirrors show identical new content for the **Branch setup** section and identical version bump.
- Existing steps (Read before writing, Smallest correct change, Prove it locally, Parallelisable work) are present and renumbered 2, 3, 4, 5.

## Detailed description (for agents)

**Problem.** Friction cluster #94 documented that the developer skill instructs agents to create branches without fetching the remote first, causing branches to be based on a stale local `main`. In multi-agent sessions, sibling agents can merge PRs concurrently; PR #92 hit this and required a rebase round-trip after pr-reviewer flagged `community-config/skills/pr-reviewer/` (merged in #89) as missing.

**Change.** Inserts a new section at the top of `## Operating mode`:

> ### 1. Branch setup
>
> Before creating your branch, always synchronise with the remote to avoid basing work on a stale commit:
>
> ```sh
> git fetch origin
> git checkout -b <branch-name> origin/main
> ```
>
> Never use `git checkout -b <branch> main` (local ref) — it may be behind `origin/main` if the remote was updated since your last fetch, which causes the branch to miss recently merged PRs and forces a rebase round-trip.

Renumbers the four pre-existing operating-mode steps from 1–4 to 2–5. Bumps the `metadata.provenance.version` field from `1.1.1` to `1.1.2` in each of the three mirrored copies.

**Files touched** (3, +60/-15):

- `community-config/skills/developer/SKILL.md` — canonical
- `.claude/skills/developer/SKILL.md` — Claude Code mirror
- `.gemini/skills/developer/SKILL.md` — Gemini CLI mirror

**Out of scope.** This is a prompt-only change to a single skill. No tests, scripts, or harness wiring touched. The auto-fix automation tracked in #42 was not used; this PR was authored by the developer agent against the friction issue.

Closes #94.
Logbook: #99.
