### PR TITLE
🐛 Check upstream issue before creating logbook in pr-logbook skill

### DIFF
--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -73,6 +73,19 @@ deletions, and the rationale for each.>
 ```
 
 ### 4. Logbook entries
+
+**Before creating a new logbook issue**, check whether the PR already closes
+an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
+`Resolves #N` patterns). If a feature issue exists:
+
+1. Append the logbook entry to that issue as a comment via the GitHub MCP
+   `add_issue_comment` tool (or `gh issue comment <N> --body "..."`).
+2. Ensure the issue carries the `logbook` label — add it with
+   `gh issue edit <N> --add-label logbook` if absent.
+3. Do **not** create a new logbook issue. The feature ticket is the logbook.
+
+A standalone logbook issue is only warranted when the PR has no upstream
+feature ticket (hotfix, dependency bump, automation run with no prior ticket).
 
 A logbook is *not* a status update. It is the record the next agent
 will read to avoid your mistakes. Optimise for that reader.

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.1.0"
+    version: "1.1.1"
 ---
 
 
@@ -69,6 +69,19 @@ deletions, and the rationale for each.>
 ```
 
 ### 4. Logbook entries
+
+**Before creating a new logbook issue**, check whether the PR already closes
+an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
+`Resolves #N` patterns). If a feature issue exists:
+
+1. Append the logbook entry to that issue as a comment via the GitHub MCP
+   `add_issue_comment` tool (or `gh issue comment <N> --body "..."`).
+2. Ensure the issue carries the `logbook` label — add it with
+   `gh issue edit <N> --add-label logbook` if absent.
+3. Do **not** create a new logbook issue. The feature ticket is the logbook.
+
+A standalone logbook issue is only warranted when the PR has no upstream
+feature ticket (hotfix, dependency bump, automation run with no prior ticket).
 
 A logbook is *not* a status update. It is the record the next agent
 will read to avoid your mistakes. Optimise for that reader.

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.0"
+    version: "1.1.1"
 claude:
   allowed-tools:
     - Read
@@ -77,6 +77,19 @@ deletions, and the rationale for each.>
 ```
 
 ### 4. Logbook entries
+
+**Before creating a new logbook issue**, check whether the PR already closes
+an existing feature issue (scan the PR body for `Closes #N`, `Fixes #N`,
+`Resolves #N` patterns). If a feature issue exists:
+
+1. Append the logbook entry to that issue as a comment via the GitHub MCP
+   `add_issue_comment` tool (or `gh issue comment <N> --body "..."`).
+2. Ensure the issue carries the `logbook` label — add it with
+   `gh issue edit <N> --add-label logbook` if absent.
+3. Do **not** create a new logbook issue. The feature ticket is the logbook.
+
+A standalone logbook issue is only warranted when the PR has no upstream
+feature ticket (hotfix, dependency bump, automation run with no prior ticket).
 
 A logbook is *not* a status update. It is the record the next agent
 will read to avoid your mistakes. Optimise for that reader.


### PR DESCRIPTION
Teaches the `pr-logbook` skill to reuse an existing upstream feature issue as the logbook surface instead of spawning a redundant ticket. Implements #95 — the friction it reports is fixed by this very PR, which applies the new rule to itself.

## How to read this PR?

1. Start with `community-config/skills/pr-logbook/SKILL.md` — that is the canonical tree. Read §4 *Logbook entries* (the only block that changed); the new pre-flight scan for `Closes #N` / `Fixes #N` / `Resolves #N` sits there.
2. The `.claude/skills/pr-logbook/SKILL.md` and `.gemini/skills/pr-logbook/SKILL.md` files mirror the same diff for each harness. Spot-check that the three trees stayed in sync.
3. Note the `metadata.version` bump (1.1.0 → 1.1.1) in all three files — that is the cheap signal downstream consumers diff against to detect the contract change.
4. The rest of the branch's commit log (`pr-reviewer`, `developer` skill tweaks) belongs to earlier merged PRs and is not part of this changeset.

## How to test this PR?

1. `git fetch origin && git checkout fix/issue-95-pr-logbook-upstream-check`.
2. `git diff main...HEAD -- '*/pr-logbook/SKILL.md'` — confirm the three mirrors carry the identical +13/-1 block and the version bump.
3. Open one of the SKILL.md files at §4 and read the new clause as if you were an agent: it must be unambiguous that scanning the PR body for `Closes #N` / `Fixes #N` / `Resolves #N` happens *before* any `gh issue create`.
4. Cross-check #95 — the logbook narrative for this PR lives as a comment on the issue (no sibling logbook issue was opened) and the `logbook` label is present. That is the live regression test.

## Detailed description (for agents)

- **Scope.** Single behavioural edit to the `pr-logbook` skill, replicated across three trees (`community-config/`, `.claude/`, `.gemini/`). No code paths, no scripts, no agent definitions touched.
- **Diff shape.** Each file gains a 13-line block immediately above the existing "A logbook is *not* a status update" paragraph in §4, and the `metadata.version` line moves from `"1.1.0"` to `"1.1.1"`. `git diff --stat` reports `+13/-1` per file.
- **Contract.** Before opening a new logbook issue, the agent MUST scan the PR body for `Closes #N`, `Fixes #N`, or `Resolves #N`. If a match exists: (a) append the logbook entry as a comment on issue `#N` via `add_issue_comment` (or `gh issue comment`), (b) ensure `#N` carries the `logbook` label, adding it via `gh issue edit <N> --add-label logbook` if absent, (c) do NOT create a standalone logbook issue. Standalone issues remain valid only when no upstream ticket exists (hotfix, dependency bump, ticketless automation run).
- **Self-application.** This PR is its own regression test. Issue #95 already exists (the friction report that motivated the change); the logbook entry for this work is posted as a comment on #95 and the `logbook` label was added to it. No new logbook issue was created.
- **Backward compatibility.** Pure additive guard before the existing logbook-authoring guidance. Agents that ignore the new clause still produce valid output — they just produce the suboptimal output that the friction report flagged. The version bump is the discovery surface.
- **Out of scope.** Tooling to auto-detect `Closes #N` and route the comment without an agent decision; cross-skill propagation to `pr-reviewer` or `developer`. Both deferred until a second friction report justifies them.
