### PR TITLE
🐛 Add idle-behavior guideline to pr-reviewer and pr-logbook

### DIFF
--- a/.claude/agents/pr-reviewer/AGENT.md
+++ b/.claude/agents/pr-reviewer/AGENT.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.0.0"
+    version: "1.0.1"
 ---
 
 
@@ -57,6 +57,14 @@ Agent(subagent_type="pr-reviewer", prompt="Review PR #<number> on hcross/crewrig
 - **Auto-triggering on push.** Wiring a webhook or GitHub Action to
   spawn this agent on every push is tracked separately — out of scope
   for the agent definition itself.
+
+## Idle behavior
+
+When re-activated after going idle with no new assignment (e.g. a
+team-lead status check), respond with a single sentence. Do not
+re-summarise a completed task in full.
+
+Example: "Task #3 (cold-start review of PR #N) is already completed — available for new work."
 
 ## Friction reporting
 

--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 
@@ -192,3 +192,10 @@ When a recognition signal fires (see `config/TOOLS.md` →
 `harness-report` skill rather than reimplementing the protocol
 inline. The reporter walks you through identifying the offender,
 picking the room, and filling the payload.
+
+## Idle behavior
+
+When re-activated after going idle with no new assignment, confirm
+availability in one sentence. Do not re-summarise a completed task.
+
+Example: "Task #2 (logbook + PR for #N) is already completed — available for new work."

--- a/.gemini/agents/pr-reviewer.md
+++ b/.gemini/agents/pr-reviewer.md
@@ -5,7 +5,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.0.0"
+    version: "1.0.1"
 ---
 
 
@@ -57,6 +57,14 @@ Agent(subagent_type="pr-reviewer", prompt="Review PR #<number> on hcross/crewrig
 - **Auto-triggering on push.** Wiring a webhook or GitHub Action to
   spawn this agent on every push is tracked separately — out of scope
   for the agent definition itself.
+
+## Idle behavior
+
+When re-activated after going idle with no new assignment (e.g. a
+team-lead status check), respond with a single sentence. Do not
+re-summarise a completed task in full.
+
+Example: "Task #3 (cold-start review of PR #N) is already completed — available for new work."
 
 ## Friction reporting
 

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.1.1"
+    version: "1.1.2"
 ---
 
 
@@ -188,3 +188,10 @@ When a recognition signal fires (see `config/TOOLS.md` →
 `harness-report` skill rather than reimplementing the protocol
 inline. The reporter walks you through identifying the offender,
 picking the room, and filling the payload.
+
+## Idle behavior
+
+When re-activated after going idle with no new assignment, confirm
+availability in one sentence. Do not re-summarise a completed task.
+
+Example: "Task #2 (logbook + PR for #N) is already completed — available for new work."

--- a/community-config/agents/pr-reviewer/AGENT.md
+++ b/community-config/agents/pr-reviewer/AGENT.md
@@ -9,7 +9,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.0.0"
+    version: "1.0.1"
 ---
 
 # PR Reviewer Agent
@@ -60,6 +60,14 @@ Agent(subagent_type="pr-reviewer", prompt="Review PR #<number> on hcross/crewrig
 - **Auto-triggering on push.** Wiring a webhook or GitHub Action to
   spawn this agent on every push is tracked separately — out of scope
   for the agent definition itself.
+
+## Idle behavior
+
+When re-activated after going idle with no new assignment (e.g. a
+team-lead status check), respond with a single sentence. Do not
+re-summarise a completed task in full.
+
+Example: "Task #3 (cold-start review of PR #N) is already completed — available for new work."
 
 ## Friction reporting
 

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.1"
+    version: "1.1.2"
 claude:
   allowed-tools:
     - Read
@@ -196,3 +196,10 @@ When a recognition signal fires (see `config/TOOLS.md` →
 `harness-report` skill rather than reimplementing the protocol
 inline. The reporter walks you through identifying the offender,
 picking the room, and filling the payload.
+
+## Idle behavior
+
+When re-activated after going idle with no new assignment, confirm
+availability in one sentence. Do not re-summarise a completed task.
+
+Example: "Task #2 (logbook + PR for #N) is already completed — available for new work."


### PR DESCRIPTION
Adds a short `Idle behavior` section to the `pr-reviewer` agent and the `pr-logbook` skill so teammates confirm availability in one sentence instead of re-summarising a completed task on every idle wake-up. Implements #96.

## How to read this PR?

Start with the canonical sources — they hold the contract:

1. `community-config/agents/pr-reviewer/AGENT.md` — new `## Idle behavior` section, provenance `1.0.0 → 1.0.1`.
2. `community-config/skills/pr-logbook/SKILL.md` — new `## Idle behavior` section, provenance `1.1.1 → 1.1.2`.

The matching edits under `.claude/` and `.gemini/` are byte-for-byte mirrors of the canonical change, kept in lock-step so the three distribution trees do not drift. The version bumps are PATCH per `community-config/skills/pr-logbook/SKILL.md` → *Cross-cutting: skill / agent source version bumps* (wording-only addition).

## How to test this PR?

1. Re-read the new `## Idle behavior` block in each of the six touched files and confirm the wording is identical across the canonical / `.claude/` / `.gemini/` triplet for each component.
2. From the repo root, run `bash scripts/check-skill-versions.sh` (or `task check-skill-versions` if available) — both bumped sources must pass the version-bump gate.
3. Spawn a `pr-reviewer` or `pr-logbook` agent, let it complete its assigned task, then send an empty wake-up. Expected: a single-sentence availability confirmation, not a re-summary of the completed work.

## Detailed description (for agents)

- `community-config/agents/pr-reviewer/AGENT.md`: appended `## Idle behavior` section before `## Friction reporting`; bumped `metadata.provenance.version` from `1.0.0` to `1.0.1`.
- `community-config/skills/pr-logbook/SKILL.md`: appended `## Idle behavior` section at end-of-file; bumped `metadata.provenance.version` from `1.1.1` to `1.1.2`.
- `.claude/agents/pr-reviewer/AGENT.md`, `.gemini/agents/pr-reviewer.md`: byte-mirror of the canonical AGENT change.
- `.claude/skills/pr-logbook/SKILL.md`, `.gemini/skills/pr-logbook/SKILL.md`: byte-mirror of the canonical SKILL change.
- No code, no scripts, no schema changes — documentation-only behavior guideline. Total: 6 files, +51 / -6 (`git diff --stat origin/main..HEAD`).

The friction is documented in #96 and the implementation logbook is appended as a comment on the same issue per the upstream-issue logbook rule (`community-config/skills/pr-logbook/SKILL.md` → *Logbook entries*).

Implements #96.