### PR TITLE
🐛 Specify logbook closing lifecycle in AGENTS.md and pr-logbook skill

### DIFF
--- a/.claude/skills/pr-logbook/SKILL.md
+++ b/.claude/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 
@@ -132,6 +132,23 @@ Text-only tooling silently drops file metadata. Verify before pushing:
   the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
   not `100644`. The MCP `push_files` tool strips the exec bit. Restore
   with `git update-index --chmod=+x <file>` and amend before pushing.
+
+### 7. Post-merge cleanup
+
+After the squash-merge commit lands on the target branch:
+
+1. Close the logbook issue:
+   `gh issue close <logbook-issue-number> --reason completed`
+   or via the GitHub MCP `issue_write` tool with `state: "closed"` and
+   `state_reason: "completed"`.
+2. If the PR also closes a feature issue (detected via `Closes #N` /
+   `Fixes #N` / `Resolves #N` in §4), confirm that issue is closed too
+   — GitHub auto-closes on merge when the keyword is in the PR body,
+   but verify rather than assume.
+
+Skip step 1 if the logbook entry was appended to an existing feature
+issue (the §4 upstream-check path) — closing the feature issue is
+sufficient.
 
 ## Cross-cutting: skill / agent source version bumps
 

--- a/.gemini/skills/pr-logbook/SKILL.md
+++ b/.gemini/skills/pr-logbook/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   provenance:
     canonical: "https://github.com/hcross/crewrig"
     feedback: "https://github.com/hcross/crewrig"
-    version: "1.1.2"
+    version: "1.1.3"
 ---
 
 
@@ -128,6 +128,23 @@ Text-only tooling silently drops file metadata. Verify before pushing:
   the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
   not `100644`. The MCP `push_files` tool strips the exec bit. Restore
   with `git update-index --chmod=+x <file>` and amend before pushing.
+
+### 7. Post-merge cleanup
+
+After the squash-merge commit lands on the target branch:
+
+1. Close the logbook issue:
+   `gh issue close <logbook-issue-number> --reason completed`
+   or via the GitHub MCP `issue_write` tool with `state: "closed"` and
+   `state_reason: "completed"`.
+2. If the PR also closes a feature issue (detected via `Closes #N` /
+   `Fixes #N` / `Resolves #N` in §4), confirm that issue is closed too
+   — GitHub auto-closes on merge when the keyword is in the PR body,
+   but verify rather than assume.
+
+Skip step 1 if the logbook entry was appended to an existing feature
+issue (the §4 upstream-check path) — closing the feature issue is
+sufficient.
 
 ## Cross-cutting: skill / agent source version bumps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,9 @@ This strategy ensures that all experience (failures and successes) from agents w
 
 Logbook issues must be written in English and use the label `logbook`.
 
+Once the PR is merged and any linked feature issue is closed, the logbook
+issue must also be closed (`state_reason: completed`).
+
 ## GitHub Access
 
 All GitHub operations (PRs, issues, branch protection) are performed through the dedicated MCP server.

--- a/community-config/skills/pr-logbook/SKILL.md
+++ b/community-config/skills/pr-logbook/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   provenance:
     canonical: "${CANONICAL_REPO}"
     feedback: "${FEEDBACK_REPO}"
-    version: "1.1.2"
+    version: "1.1.3"
 claude:
   allowed-tools:
     - Read
@@ -136,6 +136,23 @@ Text-only tooling silently drops file metadata. Verify before pushing:
   the round-trip: `git ls-files --stage -- '*.sh'` must show `100755`,
   not `100644`. The MCP `push_files` tool strips the exec bit. Restore
   with `git update-index --chmod=+x <file>` and amend before pushing.
+
+### 7. Post-merge cleanup
+
+After the squash-merge commit lands on the target branch:
+
+1. Close the logbook issue:
+   `gh issue close <logbook-issue-number> --reason completed`
+   or via the GitHub MCP `issue_write` tool with `state: "closed"` and
+   `state_reason: "completed"`.
+2. If the PR also closes a feature issue (detected via `Closes #N` /
+   `Fixes #N` / `Resolves #N` in §4), confirm that issue is closed too
+   — GitHub auto-closes on merge when the keyword is in the PR body,
+   but verify rather than assume.
+
+Skip step 1 if the logbook entry was appended to an existing feature
+issue (the §4 upstream-check path) — closing the feature issue is
+sufficient.
 
 ## Cross-cutting: skill / agent source version bumps
 


### PR DESCRIPTION
Implements #103. Codifies *who* closes a logbook issue and *when*, so the lane does not silently accumulate stale open issues after merge.

## How to read this PR?

Single commit, four files, all documentation:

1. `AGENTS.md` — three-line clause added to the *Logbook Issues* section stating that the logbook issue must be closed (`state_reason: completed`) once its PR is merged and any linked feature issue is closed. This is the human-facing rule.
2. `community-config/skills/pr-logbook/SKILL.md` — canonical source. New §7 "Post-merge cleanup" describes the close procedure (gh CLI + GitHub MCP variants) and the §4-path exception. `provenance.version` bumped per `community-config/FORMAT.md`.
3. `.claude/skills/pr-logbook/SKILL.md` and `.gemini/skills/pr-logbook/SKILL.md` — vendor mirrors of the canonical source, kept in lockstep.

The §4-path exception matters: when the PR closes an upstream feature issue (the path #95 introduced), the logbook entry lives as a comment on *that* issue, so closing the feature issue covers it — no separate close needed.

## How to test this PR?

```bash
git fetch origin
git switch fix/issue-103-logbook-closing-lifecycle
git diff main...HEAD --stat   # expect 4 files, +57/−3
grep -n "Once the PR is merged" AGENTS.md
grep -n "Post-merge cleanup" community-config/skills/pr-logbook/SKILL.md
grep -n "Post-merge cleanup" .claude/skills/pr-logbook/SKILL.md
grep -n "Post-merge cleanup" .gemini/skills/pr-logbook/SKILL.md
task check-skill-versions   # confirms the provenance.version bump on the canonical source
```

Expected: each `grep` returns one hit per file; the version check passes (the canonical `pr-logbook` SKILL.md carries the bump in the same diff).

## Detailed description (for agents)

- **`AGENTS.md`** — three new lines at the end of *Logbook Issues* establishing the close rule. Wording deliberately matches the §7 SKILL phrasing so the two sources stay synonymous.
- **`community-config/skills/pr-logbook/SKILL.md`** — new §7 "Post-merge cleanup". Two-step procedure: (1) close the logbook issue with `gh issue close <n> --reason completed` or the GitHub MCP `issue_write` tool with `state: "closed"` and `state_reason: "completed"`; (2) if the PR also closed a feature issue (via `Closes #N` / `Fixes #N` / `Resolves #N`), verify GitHub's auto-close fired rather than assume. Includes the §4-path exception: skip step 1 when the logbook entry was a comment on an existing feature issue. `provenance.version` bumped (PATCH — friction-driven clarification, no contract break).
- **`.claude/skills/pr-logbook/SKILL.md`** and **`.gemini/skills/pr-logbook/SKILL.md`** — identical §7 added; vendor mirrors track the canonical source so each harness reads the same contract.

This PR itself follows the §4-path: the logbook entry was posted as a comment on the upstream issue (#103) and the `logbook` label was applied there. **Post-merge action** (eating its own dogfood for §7): close #103 with `state_reason: completed` once this PR merges.